### PR TITLE
fix: 중복 필터링 타입 불일치 버그 수정

### DIFF
--- a/modules/google_sheets_client.py
+++ b/modules/google_sheets_client.py
@@ -112,7 +112,7 @@ class GoogleSheetsClient:
             result = self.service.spreadsheets().values().get(
                 spreadsheetId=self.spreadsheet_id,
                 range=range_name,
-                valueRenderOption='UNFORMATTED_VALUE'
+                valueRenderOption='FORMATTED_VALUE'
             ).execute()
             
             # GridData 형식으로 변환 (기존 코드와의 호환성을 위해)

--- a/modules/models.py
+++ b/modules/models.py
@@ -53,6 +53,12 @@ class Trade:
             return self.to_foreign_row()
         return self.to_domestic_row()
 
+    @staticmethod
+    def _num_str(v: float) -> str:
+        """숫자를 시트 표현과 일치하는 문자열로 변환 (정수면 소수점 제거)"""
+        return str(int(v)) if v == int(v) else str(v)
+
     def duplicate_key(self) -> tuple:
-        """중복 체크 키"""
-        return (self.date, self.trade_type, self.stock_name, self.quantity, self.price)
+        """중복 체크 키 (시트에서 읽은 값과 비교 가능하도록 문자열 통일)"""
+        return (self.date, self.trade_type, self.stock_name,
+                self._num_str(self.quantity), self._num_str(self.price))


### PR DESCRIPTION
## Summary
- Google Sheets API에서 날짜를 `UNFORMATTED_VALUE`로 읽으면 시리얼 넘버(예: `45947`)가 반환되어 `duplicate_key()`의 날짜 문자열(`2025-10-17`)과 불일치 → `FORMATTED_VALUE`로 변경
- `duplicate_key()`에서 `float` → 정수 문자열 변환 (`2.0` → `'2'`) 시트에서 읽은 값(`'2'`)과 일치하도록 수정

## Test plan
- [x] 1차 실행: 369건 정상 삽입 확인
- [x] 2차 실행: 369건 전부 중복 건너뜀 확인 (신규 거래 없음)
- [x] `pytest tests/test_parsers.py` 24개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)