### PR TITLE
feat: OpenAI 기반 섹터 분류 및 대시보드 섹터별 투자비중 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tmp/
 config/config.local.toml
 config/config.yaml
 config/config.local.yaml
+config/sector_cache.json
 
 # 환경변수 파일
 .env

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,7 +8,13 @@ google_sheets:
 logging:
   level: INFO
 
+# OpenAI 설정 (섹터 분류, optional)
+# 환경변수 STOCK_DATA_OPENAI_API_KEY 설정 시 활성화
+openai:
+  model: gpt-4o-mini
+  sector_cache_file: config/sector_cache.json
+
 # 처리 설정
 batch_size: 10
 empty_row_threshold: 100
-stock_type_cache_file: stock_type_cache.json 
+stock_type_cache_file: stock_type_cache.json

--- a/modules/sector_classifier.py
+++ b/modules/sector_classifier.py
@@ -1,0 +1,146 @@
+"""OpenAI 기반 종목 섹터 분류 모듈
+
+종목명/종목코드를 기반으로 GICS 기반 한국어 섹터로 분류.
+JSON 파일 캐시로 반복 API 호출 방지.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from openai import AsyncOpenAI
+
+logger = logging.getLogger(__name__)
+
+SECTORS = [
+    "에너지", "소재", "산업재", "경기소비재", "필수소비재",
+    "헬스케어", "금융", "IT", "통신서비스", "유틸리티", "부동산", "기타",
+]
+
+SYSTEM_PROMPT = """당신은 주식 종목 섹터 분류 전문가입니다.
+주어진 종목명과 종목코드를 보고 GICS 기반 한국어 섹터로 분류하세요.
+
+사용 가능한 섹터: 에너지, 소재, 산업재, 경기소비재, 필수소비재, 헬스케어, 금융, IT, 통신서비스, 유틸리티, 부동산, 기타
+
+규칙:
+- ETF는 주요 투자 대상 섹터로 분류
+- 분류 불가 시 "기타"
+- 반드시 JSON 형식으로만 응답: {"종목명": "섹터명", ...}
+- 다른 텍스트 없이 JSON만 출력"""
+
+
+class SectorClassifier:
+    """OpenAI API를 사용한 종목 섹터 분류기"""
+
+    def __init__(self, api_key: str, model: str = "gpt-4o-mini",
+                 cache_path: str = "config/sector_cache.json"):
+        self.openai_client = AsyncOpenAI(api_key=api_key)
+        self.model = model
+        self.cache_path = Path(cache_path)
+        self.cache: Dict[str, str] = self._load_cache()
+
+    def _load_cache(self) -> Dict[str, str]:
+        if not self.cache_path.exists():
+            return {}
+        try:
+            with open(self.cache_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                logger.warning(f"캐시 파일 형식 오류, 초기화: {self.cache_path}")
+                return {}
+            return {k: v for k, v in data.items()
+                    if isinstance(k, str) and isinstance(v, str)}
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(f"캐시 파일 로드 실패, 초기화: {e}")
+            return {}
+
+    def _save_cache(self):
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.cache_path, "w", encoding="utf-8") as f:
+            json.dump(self.cache, f, ensure_ascii=False, indent=2)
+
+    async def classify(self, stocks: List[Tuple[str, str, str]]) -> Dict[str, str]:
+        """종목 리스트를 섹터로 분류
+
+        Args:
+            stocks: (stock_name, stock_code, currency) 튜플 리스트
+
+        Returns:
+            {stock_name: 섹터명} 딕셔너리
+        """
+        result: Dict[str, str] = {}
+        uncached: List[Tuple[str, str, str]] = []
+
+        for name, code, currency in stocks:
+            if name in self.cache:
+                result[name] = self.cache[name]
+            else:
+                uncached.append((name, code, currency))
+
+        if not uncached:
+            logger.info(f"섹터 분류: 전체 {len(stocks)}건 캐시 사용")
+            return result
+
+        logger.info(f"섹터 분류: {len(uncached)}건 OpenAI 호출 (캐시 {len(result)}건)")
+
+        # 국내/해외 분리하여 배치 처리
+        domestic = [(n, c, cur) for n, c, cur in uncached if cur == "KRW"]
+        foreign = [(n, c, cur) for n, c, cur in uncached if cur != "KRW"]
+
+        if domestic:
+            classified = await self._call_openai(domestic, is_domestic=True)
+            result.update(classified)
+            self.cache.update(classified)
+
+        if foreign:
+            classified = await self._call_openai(foreign, is_domestic=False)
+            result.update(classified)
+            self.cache.update(classified)
+
+        self._save_cache()
+        return result
+
+    async def _call_openai(self, stocks: List[Tuple[str, str, str]],
+                           is_domestic: bool) -> Dict[str, str]:
+        """OpenAI API 호출로 섹터 분류"""
+        market = "한국" if is_domestic else "해외"
+        stock_list = "\n".join(
+            f"- {name} ({code})" for name, code, _ in stocks
+        )
+        user_prompt = f"다음 {market} 주식 종목들의 섹터를 분류해주세요:\n{stock_list}"
+
+        try:
+            response = await self.openai_client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0,
+                response_format={"type": "json_object"},
+                timeout=30,
+            )
+            content = response.choices[0].message.content
+            classified = json.loads(content)
+
+            # 유효한 섹터만 필터링
+            valid = {}
+            for name, sector in classified.items():
+                if sector in SECTORS:
+                    valid[name] = sector
+                else:
+                    logger.warning(f"알 수 없는 섹터 '{sector}' → '기타' 처리: {name}")
+                    valid[name] = "기타"
+
+            # 응답에서 누락된 종목 처리
+            for name, _, _ in stocks:
+                if name not in valid:
+                    logger.warning(f"OpenAI 응답에서 누락된 종목 → '기타' 처리: {name}")
+                    valid[name] = "기타"
+
+            return valid
+
+        except Exception as e:
+            logger.error(f"OpenAI 섹터 분류 실패: {e}")
+            return {name: "기타" for name, _, _ in stocks}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 
     # 설정
     "pyyaml>=6.0.1",
+
+    # OpenAI (섹터 분류)
+    "openai>=1.12.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- `SectorClassifier` 모듈 신규 생성 (AsyncOpenAI API로 종목명 → GICS 기반 한국어 섹터 분류)
- JSON 파일 캐시(`config/sector_cache.json`)로 반복 API 호출 방지
- 대시보드 투자 지표 섹션에 "섹터별 투자비중" 서브섹션 추가 (계좌별/통화별 투자비중 아래 배치)
- `STOCK_DATA_OPENAI_API_KEY` 미설정 시 섹터 섹션만 건너뜀 (기존 기능 영향 없음)

## Changes
| 파일 | 변경 |
|------|------|
| `modules/sector_classifier.py` | 신규 - AsyncOpenAI 클라이언트, 국내/해외 배치 분류, JSON 캐시 |
| `modules/summary_generator.py` | 수정 - sector_classifier 파라미터 추가, 섹터별 투자비중 서브섹션 |
| `main.py` | 수정 - SectorClassifier 생성 및 SummaryGenerator에 전달 |
| `pyproject.toml` | 수정 - openai>=1.12.0 의존성 추가 |
| `config/config.yaml` | 수정 - openai 설정 섹션 추가 |
| `.gitignore` | 수정 - sector_cache.json 추가 |

## Test plan
- [x] 기존 26개 테스트 통과 확인
- [ ] `STOCK_DATA_OPENAI_API_KEY` 설정 후 실행 → 대시보드에 섹터별 투자비중 표시 확인
- [ ] `config/sector_cache.json` 캐시 파일 생성 확인
- [ ] 재실행 시 캐시 사용 (OpenAI 미호출) 확인
- [ ] `STOCK_DATA_OPENAI_API_KEY` 없이 실행 → 섹터 섹션 건너뜀, 기존 기능 정상 동작 확인

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)