### PR TITLE
feat: 매매일지 배경색 제거 및 대시보드 헤더 색상 적용

### DIFF
--- a/modules/google_sheets_client.py
+++ b/modules/google_sheets_client.py
@@ -446,6 +446,48 @@ class GoogleSheetsClient:
             logger.error(f"시트 '{sheet_name}' 데이터 삭제 실패: {e}")
             return False
 
+    async def clear_background_colors(self, sheet_name: str, end_row: int = 1000, end_col: int = 26) -> bool:
+        """시트 전체 배경색을 제거합니다
+
+        Args:
+            sheet_name: 시트 이름
+            end_row: 초기화할 마지막 행 (기본: 1000)
+            end_col: 초기화할 마지막 열 (기본: 26, Z열)
+        """
+        try:
+            sheet_id = await self._get_sheet_id(sheet_name)
+            if sheet_id is None:
+                logger.error(f"시트 '{sheet_name}'를 찾을 수 없습니다")
+                return False
+
+            requests = [{
+                'repeatCell': {
+                    'range': {
+                        'sheetId': sheet_id,
+                        'startRowIndex': 0,
+                        'endRowIndex': end_row,
+                        'startColumnIndex': 0,
+                        'endColumnIndex': end_col,
+                    },
+                    'cell': {
+                        'userEnteredFormat': {}
+                    },
+                    'fields': 'userEnteredFormat.backgroundColor'
+                }
+            }]
+
+            self.service.spreadsheets().batchUpdate(
+                spreadsheetId=self.spreadsheet_id,
+                body={'requests': requests}
+            ).execute()
+
+            logger.info(f"시트 '{sheet_name}' 배경색 초기화 완료")
+            return True
+
+        except HttpError as e:
+            logger.error(f"시트 '{sheet_name}' 배경색 초기화 실패: {e}")
+            return False
+
     async def freeze_rows(self, sheet_name: str, row_count: int = 1) -> bool:
         """시트의 상단 N행을 고정
 


### PR DESCRIPTION
## Summary
- 매매일지 시트의 날짜별 배경색 팔레트(`COLOR_PALETTE`) 및 색상 적용 로직 제거
- 대시보드 초기화 시 기존 배경색을 클리어하고 헤더 행만 파란색 배경 적용
- `GoogleSheetsClient`에 `clear_background_colors()` 메서드 추가

## Test plan
- [x] `python main.py` 실행 후 대시보드가 배경색 없이 재생성되는지 확인
- [ ] 매매일지 시트에서 날짜별 색상이 적용되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)