### PR TITLE
fix: macOS NFD 유니코드 정규화로 해외주식 포맷 감지 오류 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import argparse
 import asyncio
 import logging
 import os
+import unicodedata
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -94,8 +95,10 @@ class StockDataProcessor:
             if not broker_dir.is_dir():
                 continue
             for csv_file in sorted(broker_dir.glob("*.csv")):
-                account_type = csv_file.stem  # "국내계좌" or "해외계좌"
-                results.append((broker_dir.name, account_type, csv_file))
+                # macOS NFD 정규화 대응: 파일명을 NFC로 통일
+                broker_name = unicodedata.normalize("NFC", broker_dir.name)
+                account_type = unicodedata.normalize("NFC", csv_file.stem)
+                results.append((broker_name, account_type, csv_file))
 
         logger.info(f"CSV 파일 {len(results)}개 발견")
         return results

--- a/modules/google_sheets_client.py
+++ b/modules/google_sheets_client.py
@@ -424,6 +424,33 @@ class GoogleSheetsClient:
             logger.error(f"시트 '{title}' 생성 실패: {e}")
             return False
 
+    async def delete_sheet(self, sheet_name: str) -> bool:
+        """시트(탭)를 삭제합니다
+
+        Args:
+            sheet_name: 삭제할 시트 이름
+
+        Returns:
+            성공 여부
+        """
+        try:
+            sheet_id = await self._get_sheet_id(sheet_name)
+            if sheet_id is None:
+                logger.warning(f"시트 '{sheet_name}'를 찾을 수 없습니다")
+                return False
+            requests = [{"deleteSheet": {"sheetId": sheet_id}}]
+            body = {"requests": requests}
+            self.service.spreadsheets().batchUpdate(
+                spreadsheetId=self.spreadsheet_id,
+                body=body
+            ).execute()
+            logger.info(f"시트 '{sheet_name}' 삭제 완료")
+            self.invalidate_sheet_id_cache()
+            return True
+        except HttpError as e:
+            logger.error(f"시트 '{sheet_name}' 삭제 실패: {e}")
+            return False
+
     async def clear_sheet(self, sheet_name: str, start_row: int = 2) -> bool:
         """시트 데이터를 삭제합니다 (헤더 유지)
 


### PR DESCRIPTION
## Summary
- macOS 파일시스템이 한글 파일명을 NFD(분해형)로 저장하여 `"해외" in account_type` 검사가 실패하는 버그 수정
- `해외주식1.csv`가 국내 포맷(9컬럼, ₩)으로 시트 생성되던 문제 → 해외 포맷(15컬럼, $)으로 정상 생성
- `main.py`의 `scan_csv_files()`에서 파일명을 NFC로 정규화
- `GoogleSheetsClient`에 `delete_sheet()` 메서드 추가

## Root Cause
macOS 파일시스템(APFS/HFS+)은 한글 파일명을 NFD(Normalization Form Decomposed)로 저장합니다.
Python 문자열 리터럴 `"해외"`는 NFC(Normalization Form Composed)이므로,
`"해외" in "해외주식1"(NFD)` → `False`가 되어 `is_foreign` 판별이 실패했습니다.

## Test plan
- [x] `python main.py` 실행하여 해외주식1 시트가 15컬럼 해외 포맷으로 생성됨 확인
- [x] 기존 국내 시트들(IRP, ISA, 주식1~3, 연금저축1~2)은 정상 동작 확인
- [x] 대시보드 정상 갱신 확인