### PR TITLE
feat: run.sh에 CSV 인코딩 변환 단계 추가 (CP949 → UTF-8)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -41,6 +41,23 @@ echo -e "${BLUE}로그 레벨: DEBUG${NC}"
 echo -e "${BLUE}로그 파일: $LOG_FILE${NC}"
 echo ""
 
+# CSV 인코딩 변환 (CP949 → UTF-8)
+echo -e "${BLUE}=== CSV 인코딩 확인 및 변환 ===${NC}"
+CONVERTED=0
+SKIPPED=0
+while IFS= read -r -d '' csv_file; do
+    encoding=$(file -I "$csv_file" | grep -o 'charset=.*' | cut -d= -f2)
+    if [[ "$encoding" == "utf-8" ]]; then
+        SKIPPED=$((SKIPPED + 1))
+    else
+        iconv -f CP949 -t UTF-8 "$csv_file" > "$csv_file.tmp" && mv "$csv_file.tmp" "$csv_file"
+        echo -e "${GREEN}  변환 완료: $(basename "$csv_file")${NC}"
+        CONVERTED=$((CONVERTED + 1))
+    fi
+done < <(find input -name "*.csv" -print0 2>/dev/null)
+echo -e "${BLUE}인코딩 변환: ${CONVERTED}개 변환, ${SKIPPED}개 스킵 (이미 UTF-8)${NC}"
+echo ""
+
 # Python 스크립트 실행 (DEBUG 레벨로 설정하고 로그 파일에 저장)
 # tee를 사용하여 터미널과 파일 모두에 출력
 python main.py --log-level DEBUG 2>&1 | tee "$LOG_FILE"


### PR DESCRIPTION
## Summary
- `run.sh`에서 `main.py` 실행 전 CSV 인코딩 자동 변환 단계 추가
- `input/` 하위 CSV 파일을 `file -I`로 인코딩 감지 후, UTF-8이 아니면 `iconv -f CP949 -t UTF-8`로 변환
- 변환/스킵 결과를 색상 로그로 출력

## Test plan
- [ ] `input/` 폴더에 CP949 인코딩 CSV를 넣고 `./run.sh` 실행 → 변환 로그 확인
- [ ] 두 번째 실행 시 "스킵" 처리 확인
- [ ] `input/` 폴더가 비어있을 때 오류 없이 통과하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)