### PR TITLE
fix: CSV 끝 빈 행 건너뛰기 (미래에셋 파서)

### DIFF
--- a/modules/parsers/mirae_parser.py
+++ b/modules/parsers/mirae_parser.py
@@ -59,6 +59,8 @@ class MiraeDomesticParser(BaseParser):
                     continue
                 date_raw = row[0].strip()
                 stock_name = row[1].strip()
+                if not date_raw and not stock_name:
+                    continue  # 빈 행 건너뜀
                 if not date_raw:
                     raise ValueError(f"날짜가 비어있습니다: {file_path.name}, {line_num}행")
                 if not stock_name:
@@ -170,6 +172,8 @@ class MiraeForeignParser(BaseParser):
                 currency = row[1].strip()
                 stock_code = row[2].strip()
                 stock_name = row[3].strip()
+                if not date_raw and not stock_name:
+                    continue  # 빈 행 건너뜀
                 if not date_raw:
                     raise ValueError(f"날짜가 비어있습니다: {file_path.name}, {line_num}행")
                 if not stock_name:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -114,6 +114,21 @@ class TestMiraeDomesticParser:
         with pytest.raises(ValueError, match="날짜가 비어있습니다"):
             parser.parse(csv_file, "테스트")
 
+    def test_skip_trailing_empty_rows(self, parser, tmp_path):
+        """CSV 끝의 빈 행(쉼표만 있는 행)은 건너뜀"""
+        csv_file = tmp_path / "trailing_empty.csv"
+        csv_file.write_text(
+            "일자,종목명,기간 중 매수,,,기간 중 매도,,,매매비용,손익금액,수익률\n"
+            ",,,,,,,,,,,\n"
+            "2026/02/20,삼성전자,10,50000,500000,0,0,0,0,0,0\n"
+            ",,,,,,,,,,\n"
+            ",,,,,,,,,,\n",
+            encoding="utf-8",
+        )
+        trades = parser.parse(csv_file, "테스트")
+        assert len(trades) == 1
+        assert trades[0].stock_name == "삼성전자"
+
 
 class TestMiraeForeignParser:
     """미래에셋증권 해외계좌 파서 테스트"""
@@ -201,6 +216,24 @@ class TestMiraeForeignParser:
         )
         with pytest.raises(ValueError, match="날짜가 비어있습니다"):
             parser.parse(csv_file, "테스트")
+
+    def test_skip_trailing_empty_rows(self, parser, tmp_path):
+        """CSV 끝의 빈 행(쉼표만 있는 행)은 건너뜀"""
+        csv_file = tmp_path / "trailing_empty.csv"
+        csv_file.write_text(
+            "매매일,통화,종목번호,종목명,잔고 수량,매입평균환율,매매일환율,"
+            "매수 수량,매수단가,매수금액,원화매수금액,"
+            "매도 수량,매도단가,매도금액,원화매도금액,"
+            "수수료,세금,원화총비용,원매수평균가,"
+            "매매손익,원화매매손익,환차손익,총평가손익,손익률,환산손익률\n"
+            "2026/02/20,USD,AAPL,Apple Inc,0,1300,1300,10,150,1500,1950000,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n"
+            ",,,,,,,,,,,,,,,,,,,,,,,,,\n"
+            ",,,,,,,,,,,,,,,,,,,,,,,,,\n",
+            encoding="utf-8",
+        )
+        trades = parser.parse(csv_file, "테스트")
+        assert len(trades) == 1
+        assert trades[0].stock_name == "Apple Inc"
 
 
 class TestHankookDomesticParser:


### PR DESCRIPTION
## Summary
- 미래에셋 CSV 파일 끝에 쉼표만 있는 빈 행(`,,,,,,,,,,,`)이 포함되어 파싱 실패하던 문제 수정
- 날짜와 종목명이 모두 비어있으면 빈 행으로 판단하여 `continue`로 건너뜀
- 날짜만 비어있고 종목명이 있는 비정상 행에서는 기존처럼 `ValueError` 발생

## 영향받는 파일
- `IRP.csv` (8행), `연금저축1.csv` (6행), `연금저축2.csv` (7행), `주식3.csv` (19행)

## Changes
- `modules/parsers/mirae_parser.py`: 국내/해외 파서에 빈 행 skip 로직 추가
- `tests/test_parsers.py`: 빈 꼬리 행 skip 테스트 2개 추가

## Test plan
- [x] `pytest` 55개 테스트 전체 통과 (신규 2개 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)