### PR TITLE
feat: 대시보드 월별 매수/매도 건수·금액 추이 차트 추가

### DIFF
--- a/modules/summary_generator.py
+++ b/modules/summary_generator.py
@@ -767,33 +767,37 @@ class SummaryGenerator:
         return groups
 
     async def _write_trade_count_data(self, trades: List[Trade]):
-        """월별 매수/매도 건수 차트용 데이터를 Q~S열에 작성"""
-        month_counts: Dict[str, Dict[str, int]] = defaultdict(
-            lambda: {"buy": 0, "sell": 0}
+        """월별 매수/매도 건수·금액 차트용 데이터를 Q~U열에 작성"""
+        month_stats: Dict[str, Dict[str, float]] = defaultdict(
+            lambda: {"buy_count": 0, "sell_count": 0,
+                     "buy_amount": 0.0, "sell_amount": 0.0}
         )
         for t in trades:
             month = t.date[:7]
             if t.trade_type == "매수":
-                month_counts[month]["buy"] += 1
+                month_stats[month]["buy_count"] += 1
+                month_stats[month]["buy_amount"] += t.amount_krw
             elif t.trade_type == "매도":
-                month_counts[month]["sell"] += 1
+                month_stats[month]["sell_count"] += 1
+                month_stats[month]["sell_amount"] += t.amount_krw
 
-        if not month_counts:
+        if not month_stats:
             self._trade_count_data_range = None
             return
 
-        rows = [["연월", "매수건수", "매도건수"]]
-        for month in sorted(month_counts.keys()):
-            c = month_counts[month]
-            rows.append([month, c["buy"], c["sell"]])
+        rows = [["연월", "매수건수", "매도건수", "매수금액(원)", "매도금액(원)"]]
+        for month in sorted(month_stats.keys()):
+            s = month_stats[month]
+            rows.append([month, s["buy_count"], s["sell_count"],
+                         s["buy_amount"], s["sell_amount"]])
 
         start_row = 1
         end_row = start_row + len(rows) - 1
         await self.client.batch_update_cells(
-            DASHBOARD_SHEET, {f"Q{start_row}:S{end_row}": rows}
+            DASHBOARD_SHEET, {f"Q{start_row}:U{end_row}": rows}
         )
         self._trade_count_data_range = (start_row, end_row)
-        logger.info(f"월별 매수/매도 건수 차트 데이터: {len(rows) - 1}개월 작성")
+        logger.info(f"월별 매수/매도 차트 데이터: {len(rows) - 1}개월 작성")
 
     async def _create_charts(self, trend_start: int, trend_end: int):
         """대시보드 차트 생성
@@ -875,9 +879,11 @@ class SummaryGenerator:
             width=450, height=370,
         ))
 
-        # 차트 5: 월별 매수/매도 건수 추이 (Column, 그룹)
+        # 차트 5, 6: 월별 매수/매도 건수·금액 추이
         if self._trade_count_data_range:
             tc_start, tc_end = self._trade_count_data_range
+
+            # 차트 5: 건수 추이 (Column, 그룹)
             chart_specs.append(self._build_basic_chart_spec(
                 sheet_id=sheet_id,
                 title="월별 매수/매도 건수 추이",
@@ -888,6 +894,20 @@ class SummaryGenerator:
                 data_end=tc_end,
                 anchor_row=CHART_ROW_SPACING * 3,
                 anchor_col=CHART_COL_START,
+                width=600, height=370,
+            ))
+
+            # 차트 6: 금액 추이 (Column, 그룹)
+            chart_specs.append(self._build_basic_chart_spec(
+                sheet_id=sheet_id,
+                title="월별 매수/매도 금액 추이",
+                chart_type="COLUMN",
+                domain_col=16,          # Q열 (연월)
+                series_cols=[19, 20],   # T열 (매수금액), U열 (매도금액)
+                data_start=tc_start - 1,
+                data_end=tc_end,
+                anchor_row=CHART_ROW_SPACING * 3,
+                anchor_col=CHART_COL_SECONDARY,
                 width=600, height=370,
             ))
 

--- a/modules/summary_generator.py
+++ b/modules/summary_generator.py
@@ -36,6 +36,7 @@ class SummaryGenerator:
         self.sheet_writer = sheet_writer
         self.sector_classifier = sector_classifier
         self._pie_data_range: Optional[Tuple[int, int]] = None
+        self._trade_count_data_range: Optional[Tuple[int, int]] = None
 
     async def generate_all(self, all_trades: List[Trade]):
         """대시보드 시트 생성 (초기화 후 재작성)"""
@@ -65,7 +66,8 @@ class SummaryGenerator:
                                             insights_start, trend_start,
                                             stock_start, current_row)
 
-        # 차트 생성
+        # 차트용 데이터 작성 및 차트 생성
+        await self._write_trade_count_data(all_trades)
         await self._create_charts(
             trend_start=trend_start,
             trend_end=stock_start - 1,
@@ -764,6 +766,35 @@ class SummaryGenerator:
         groups.append((start, end))
         return groups
 
+    async def _write_trade_count_data(self, trades: List[Trade]):
+        """월별 매수/매도 건수 차트용 데이터를 Q~S열에 작성"""
+        month_counts: Dict[str, Dict[str, int]] = defaultdict(
+            lambda: {"buy": 0, "sell": 0}
+        )
+        for t in trades:
+            month = t.date[:7]
+            if t.trade_type == "매수":
+                month_counts[month]["buy"] += 1
+            elif t.trade_type == "매도":
+                month_counts[month]["sell"] += 1
+
+        if not month_counts:
+            self._trade_count_data_range = None
+            return
+
+        rows = [["연월", "매수건수", "매도건수"]]
+        for month in sorted(month_counts.keys()):
+            c = month_counts[month]
+            rows.append([month, c["buy"], c["sell"]])
+
+        start_row = 1
+        end_row = start_row + len(rows) - 1
+        await self.client.batch_update_cells(
+            DASHBOARD_SHEET, {f"Q{start_row}:S{end_row}": rows}
+        )
+        self._trade_count_data_range = (start_row, end_row)
+        logger.info(f"월별 매수/매도 건수 차트 데이터: {len(rows) - 1}개월 작성")
+
     async def _create_charts(self, trend_start: int, trend_end: int):
         """대시보드 차트 생성
 
@@ -843,6 +874,22 @@ class SummaryGenerator:
             anchor_col=CHART_COL_SECONDARY,
             width=450, height=370,
         ))
+
+        # 차트 5: 월별 매수/매도 건수 추이 (Column, 그룹)
+        if self._trade_count_data_range:
+            tc_start, tc_end = self._trade_count_data_range
+            chart_specs.append(self._build_basic_chart_spec(
+                sheet_id=sheet_id,
+                title="월별 매수/매도 건수 추이",
+                chart_type="COLUMN",
+                domain_col=16,          # Q열 (연월)
+                series_cols=[17, 18],   # R열 (매수건수), S열 (매도건수)
+                data_start=tc_start - 1,
+                data_end=tc_end,
+                anchor_row=CHART_ROW_SPACING * 3,
+                anchor_col=CHART_COL_START,
+                width=600, height=370,
+            ))
 
         if chart_specs:
             await self.client.add_charts(chart_specs)

--- a/modules/summary_generator.py
+++ b/modules/summary_generator.py
@@ -797,6 +797,16 @@ class SummaryGenerator:
             DASHBOARD_SHEET, {f"Q{start_row}:U{end_row}": rows}
         )
         self._trade_count_data_range = (start_row, end_row)
+
+        # 금액 컬럼(T, U)에 숫자 포맷 적용 (차트 Y축 과학적 표기법 방지)
+        amount_formats = [
+            {'col': 20, 'pattern': '₩#,##0'},  # T열: 매수금액
+            {'col': 21, 'pattern': '₩#,##0'},  # U열: 매도금액
+        ]
+        await self.client.apply_number_format_to_columns(
+            DASHBOARD_SHEET, amount_formats, start_row + 1, end_row
+        )
+
         logger.info(f"월별 매수/매도 차트 데이터: {len(rows) - 1}개월 작성")
 
     async def _create_charts(self, trend_start: int, trend_end: int):


### PR DESCRIPTION
## Summary
- 월별 매수·매도 건수 추이 그룹 Column 차트 추가
- 월별 매수·매도 금액 추이 그룹 Column 차트 추가 (나란히 배치)
- Q~U열에 차트 전용 데이터(연월, 매수건수, 매도건수, 매수금액, 매도금액) 작성
- 금액 셀에 ₩#,##0 포맷 적용하여 Y축 과학적 표기법 방지

## Test plan
- [x] 기존 102개 테스트 통과
- [x] 실제 시트에서 차트 6개 생성 확인 (기존 4 + 신규 2)
- [x] 재실행 시 기존 차트 삭제 후 재생성 정상 동작
- [x] 금액 차트 Y축 원화 포맷 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)