### PR TITLE
fix: 국내 종목코드 보강이 "국내" 미포함 계좌명에서 누락되는 문제 수정

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -24,11 +24,13 @@ class Trade:
     profit_rate: float  # 수익률(%)
     account: str  # 증권사_계좌유형 (예: "미래에셋증권_국내계좌")
 
-    def is_domestic(self) -> bool:
-        return "국내" in self.account
-
     def is_foreign(self) -> bool:
         return "해외" in self.account
+
+    def is_domestic(self) -> bool:
+        # 행 포맷 선택(to_sheet_row)과 동일하게 "해외가 아니면 국내"로 판정.
+        # 계좌명에 "국내" 리터럴이 없어도(예: "미래에셋증권_주식2") 보강 대상에 포함된다.
+        return not self.is_foreign()
 
     def to_domestic_row(self) -> list:
         """국내계좌 시트 행 변환 (10컬럼)

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -33,3 +33,11 @@ def test_skips_foreign_trades():
     trades = [_trade("애플", "", account="미래에셋증권_해외계좌")]
     enrich_domestic_codes(trades, resolver)
     assert trades[0].stock_code == ""  # 해외는 건드리지 않음
+
+
+def test_fills_code_when_account_has_no_domestic_keyword():
+    # 계좌명이 "국내"를 포함하지 않아도(예: "주식2") 해외가 아니면 국내로 간주해 보강한다
+    resolver = SymbolResolver(name_to_code={"KODEX 미국AI전력핵심인프라": "487230"})
+    trades = [_trade("KODEX 미국AI전력핵심인프라", "", account="미래에셋증권_주식2")]
+    enrich_domestic_codes(trades, resolver)
+    assert trades[0].stock_code == "487230"


### PR DESCRIPTION
## 문제

미래에셋 국내 ETF 거래의 종목코드(D열)가 비어 있음. CSV 파일명이 `주식2.csv`라 계좌명이 `미래에셋증권_주식2`가 되는데, 여기엔 `"국내"` 키워드가 없음.

## 근본 원인

| 판정 | 기준 | `미래에셋증권_주식2` 결과 |
|------|------|----------------------|
| 행 포맷 (`to_sheet_row`) | `is_foreign()`의 부정 | 국내 10컬럼 포맷 (종목코드 컬럼 생성) ✅ |
| 종목코드 보강 (`enrich_domestic_codes`) | `is_domestic()` = `"국내" in account` | **False → 보강 스킵** ❌ |

두 판정이 서로 다른 기준을 써서 어긋남. KRX 리졸버 자체는 정상.

## 변경

- `Trade.is_domestic()`을 `return not self.is_foreign()`로 변경 — `to_sheet_row()` 포맷 선택과 동일 기준으로 일관화

## 주의 (별도)

기존에 이미 삽입된 빈 종목코드 행은 `duplicate_key()`에 종목코드가 없어 재실행해도 중복으로 스킵됨. 백필하려면 시트/행 삭제 후 재실행 필요. 새 거래는 이번 수정으로 정상 채워짐.

## Test plan

- [x] `test_fills_code_when_account_has_no_domestic_keyword` 추가 (계좌명에 "국내" 없어도 보강)
- [x] 기존 enrichment 테스트 3건 유지 (해외 스킵, 기존 코드 보존)
- [x] 전체 138개 테스트 통과