### PR TITLE
feat: 종목코드 컬럼을 종목명 왼쪽으로 이동

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ StockDataProcessor (main.py)
 
 **Trade** (dataclass):
 - 16개 필드: date, trade_type, stock_name, stock_code, quantity, price, amount, currency, exchange_rate, amount_krw, fee, tax, profit, profit_krw, profit_rate, account
-- `to_domestic_row()`: 국내 10컬럼 행 반환 (일자, 구분, 종목명, 종목코드, 수량, 단가, 금액, 수수료, 손익금액, 수익률)
+- `to_domestic_row()`: 국내 10컬럼 행 반환 (일자, 구분, 종목코드, 종목명, 수량, 단가, 금액, 수수료, 손익금액, 수익률)
 - `to_foreign_row()`: 해외 15컬럼 행 반환
 - `duplicate_key()`: (date, trade_type, stock_name, quantity, price) 튜플
 
@@ -157,8 +157,8 @@ logging:
 
 ### 국내 시트 컬럼 (종목코드 추가)
 
-국내계좌 시트는 종목명 뒤에 `종목코드` 컬럼을 포함한 **10컬럼** 구조입니다
-(일자, 구분, 종목명, 종목코드, 수량, 단가, 금액, 수수료, 손익금액, 수익률(%)).
+국내계좌 시트는 종목명 앞에 `종목코드` 컬럼을 포함한 **10컬럼** 구조입니다
+(일자, 구분, 종목코드, 종목명, 수량, 단가, 금액, 수수료, 손익금액, 수익률(%)).
 종목코드는 미래에셋 국내처럼 CSV에 코드가 없는 경우 KRX 공개 종목 마스터
 (`modules/symbol_master.py`)에서 종목명으로 조회해 채웁니다.
 

--- a/modules/models.py
+++ b/modules/models.py
@@ -37,7 +37,7 @@ class Trade:
         수익률은 퍼센트 소수로 변환 (14.68 → 0.1468)
         """
         return [
-            self.date, self.trade_type, self.stock_name, self.stock_code,
+            self.date, self.trade_type, self.stock_code, self.stock_name,
             self.quantity, self.price, self.amount,
             self.fee, self.profit,
             self.profit_rate / 100 if self.profit_rate else 0,

--- a/modules/sheet_writer.py
+++ b/modules/sheet_writer.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 # 시트 헤더 상수
 DOMESTIC_HEADERS = [
-    "일자", "구분", "종목명", "종목코드", "수량", "단가", "금액",
+    "일자", "구분", "종목코드", "종목명", "수량", "단가", "금액",
     "수수료", "손익금액", "수익률(%)",
 ]
 
@@ -142,7 +142,7 @@ class SheetWriter:
                     ev = cell.get("effectiveValue", {})
                     return ev.get("stringValue") or ev.get("numberValue")
 
-                # 국내: (일자, 구분, 종목명, 수량, 단가) = cols 0,1,2,4,5
+                # 국내: (일자, 구분, 종목명, 수량, 단가) = cols 0,1,3,4,5
                 # 해외: (일자, 구분, 종목명, 수량, 단가) = cols 0,1,4,5,6
                 trade_type = str(_get_cell_value(values[1]) or "")
                 if is_foreign and len(values) >= 7:
@@ -151,8 +151,8 @@ class SheetWriter:
                            _normalize_num(_get_cell_value(values[5])),
                            _normalize_num(_get_cell_value(values[6])))
                 else:
-                    # 국내(10컬럼): 종목명=2, 종목코드=3, 수량=4, 단가=5
-                    stock_name = str(_get_cell_value(values[2]) or "")
+                    # 국내(10컬럼): 종목코드=2, 종목명=3, 수량=4, 단가=5
+                    stock_name = str(_get_cell_value(values[3]) or "")
                     key = (date_val, trade_type, stock_name,
                            _normalize_num(_get_cell_value(values[4])),
                            _normalize_num(_get_cell_value(values[5])))
@@ -487,14 +487,14 @@ def _row_to_trade(
                 account=sheet_name,
             )
         else:
-            # 국내: A~J (10컬럼) — 일자,구분,종목명,종목코드,수량,단가,금액,수수료,손익,수익률
+            # 국내: A~J (10컬럼) — 일자,구분,종목코드,종목명,수량,단가,금액,수수료,손익,수익률
             amount = _get_num(values[6])
             profit = _get_num(values[8])
             return Trade(
                 date=date_val,
                 trade_type=_get_str(values[1]),
-                stock_name=_get_str(values[2]),
-                stock_code=_get_str(values[3]),
+                stock_code=_get_str(values[2]),
+                stock_name=_get_str(values[3]),
                 quantity=_get_num(values[4]),
                 price=_get_num(values[5]),
                 amount=amount,

--- a/modules/summary_generator.py
+++ b/modules/summary_generator.py
@@ -210,7 +210,7 @@ class SummaryGenerator:
     async def _write_stock_summary(self, trades: List[Trade], start_row: int) -> int:
         """섹션 3: 종목별 현황"""
         headers = [
-            "종목명", "종목코드", "계좌", "통화",
+            "종목코드", "종목명", "계좌", "통화",
             "총매수수량", "총매수금액(원)", "총매도수량", "총매도금액(원)",
             "실현손익(원)", "수익률(%)", "투자비중(%)",
         ]
@@ -239,7 +239,7 @@ class SummaryGenerator:
             profit_rate = g["profit"] / g["sell_amount"] if g["sell_amount"] else 0
             weight = g["buy_amount"] / total_buy_amount if total_buy_amount else 0
             rows.append([
-                name, code, account, currency,
+                code, name, account, currency,
                 g["buy_qty"], g["buy_amount"],
                 g["sell_qty"], g["sell_amount"],
                 g["profit"], profit_rate, weight,

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -88,12 +88,12 @@ class TestMiraeDomesticParser:
         trades = parser.parse(sample_file, "미래에셋증권_국내계좌")
         row = trades[0].to_domestic_row()
         assert len(row) == 10
-        # 새 10컬럼 레이아웃: 일자(0), 구분(1), 종목명(2), 종목코드(3), 수량(4),
+        # 새 10컬럼 레이아웃: 일자(0), 구분(1), 종목코드(2), 종목명(3), 수량(4),
         # 단가(5), 금액(6), 수수료(7), 손익금액(8), 수익률(9)
         assert isinstance(row[0], str)   # 일자: YYYY-MM-DD
         assert row[1] in ("매수", "매도")  # 구분
-        assert isinstance(row[2], str)   # 종목명
-        assert isinstance(row[3], str)   # 종목코드 (str, "" 허용)
+        assert isinstance(row[2], str)   # 종목코드 (str, "" 허용)
+        assert isinstance(row[3], str)   # 종목명
         assert isinstance(row[4], (int, float)) and row[4] > 0  # 수량
 
     def test_profit_rate_as_decimal(self, parser, sample_file):
@@ -328,9 +328,9 @@ def _domestic_trade(**kw):
 def test_to_domestic_row_includes_stock_code():
     row = _domestic_trade().to_domestic_row()
     assert len(row) == 10
-    # 일자, 구분, 종목명, 종목코드, 수량, 단가, 금액, 수수료, 손익금액, 수익률
-    assert row[2] == "TIGER 조선TOP10"
-    assert row[3] == "494670"
+    # 일자, 구분, 종목코드, 종목명, 수량, 단가, 금액, 수수료, 손익금액, 수익률
+    assert row[2] == "494670"
+    assert row[3] == "TIGER 조선TOP10"
     assert row[4] == 2
 
 

--- a/tests/test_sheet_reader.py
+++ b/tests/test_sheet_reader.py
@@ -69,8 +69,8 @@ def writer(mock_client):
 DOMESTIC_ROW = [
     "2026-02-13",  # A: 일자
     "매수",         # B: 구분
-    "TIGER 조선TOP10",  # C: 종목명
-    "494670",       # D: 종목코드
+    "494670",       # C: 종목코드
+    "TIGER 조선TOP10",  # D: 종목명
     2.0,            # E: 수량
     28230.0,        # F: 단가
     56460.0,        # G: 금액
@@ -82,8 +82,8 @@ DOMESTIC_ROW = [
 DOMESTIC_SELL_ROW = [
     "2026-02-13",
     "매도",
-    "KODEX 미국배당다우존스",
     "229200",       # 종목코드
+    "KODEX 미국배당다우존스",  # 종목명
     9.0,
     12452.0,
     112068.0,
@@ -358,10 +358,10 @@ class TestReadAllTrades:
 
 
 def test_row_to_trade_domestic_reads_stock_code():
-    # 일자, 구분, 종목명, 종목코드, 수량, 단가, 금액, 수수료, 손익, 수익률
+    # 일자, 구분, 종목코드, 종목명, 수량, 단가, 금액, 수수료, 손익, 수익률
     values = [
-        _cell("2026-02-13"), _cell("매수"), _cell("TIGER 조선TOP10"),
-        _cell("494670"), _cell(2), _cell(28230), _cell(56460),
+        _cell("2026-02-13"), _cell("매수"), _cell("494670"),
+        _cell("TIGER 조선TOP10"), _cell(2), _cell(28230), _cell(56460),
         _cell(0), _cell(0), _cell(0.0),
     ]
     trade = _row_to_trade(values, "미래에셋증권_국내계좌", is_foreign=False,
@@ -377,13 +377,13 @@ def test_row_to_trade_domestic_reads_stock_code():
 async def test_get_existing_keys_domestic(writer, mock_client):
     """get_existing_keys()가 국내 행에서 올바른 5-tuple 키를 반환하는지 검증.
 
-    국내 10컬럼 레이아웃: 일자(0), 구분(1), 종목명(2), 종목코드(3), 수량(4), 단가(5), ...
+    국내 10컬럼 레이아웃: 일자(0), 구분(1), 종목코드(2), 종목명(3), 수량(4), 단가(5), ...
     키: (date, trade_type, stock_name, _normalize_num(qty), _normalize_num(price))
     숫자 셀은 numberValue로 저장되므로 _normalize_num(2.0) → "2", _normalize_num(28230.0) → "28230"
     """
-    # 국내 10컬럼 행 2개: 일자, 구분, 종목명, 종목코드, 수량, 단가, 금액, 수수료, 손익금액, 수익률
-    row1 = ["2026-02-13", "매수", "TIGER 조선TOP10", "494670", 2, 28230, 56460, 0, 0, 0.0]
-    row2 = ["2026-02-14", "매도", "KODEX 미국배당다우존스", "229200", 9, 12452, 112068, 2794, 16128, 0.1681]
+    # 국내 10컬럼 행 2개: 일자, 구분, 종목코드, 종목명, 수량, 단가, 금액, 수수료, 손익금액, 수익률
+    row1 = ["2026-02-13", "매수", "494670", "TIGER 조선TOP10", 2, 28230, 56460, 0, 0, 0.0]
+    row2 = ["2026-02-14", "매도", "229200", "KODEX 미국배당다우존스", 9, 12452, 112068, 2794, 16128, 0.1681]
     grid_data = _build_grid_data([row1, row2])
     mock_client.get_raw_grid_data.return_value = grid_data
 


### PR DESCRIPTION
## Summary

종목코드를 종목명 **왼쪽**으로 이동해, 종목명+종목코드를 함께 보여주는 모든 시트의 컬럼 순서를 통일합니다.

| 위치 | 변경 |
|------|------|
| 국내계좌 시트 | `종목명, 종목코드` → `종목코드, 종목명` |
| 대시보드 "종목별 현황" | `종목명, 종목코드` → `종목코드, 종목명` |
| 해외계좌 시트 | 이미 `종목코드, 종목명` 순 → 무변경 |

## Changes

- `DOMESTIC_HEADERS`: 컬럼 순서 swap (숫자 포맷은 5~10열 그대로라 `DOMESTIC_FORMATS` 무변경)
- `Trade.to_domestic_row()`: `stock_code, stock_name` 순 출력
- `get_existing_keys` / `_row_to_trade`: 국내 종목명 인덱스 2 → 3
- `_write_stock_summary`: 헤더·행을 `종목코드, 종목명` 순으로 변경
- CLAUDE.md 컬럼 순서 설명 갱신

## 마이그레이션

기존 국내 시트는 이미 삭제된 상태라 별도 마이그레이션 처리 불필요. 새 시트가 새 순서로 생성됩니다.

## Test plan

- [x] `test_parsers.py` 국내 행 레이아웃 테스트 갱신 (종목코드=2, 종목명=3)
- [x] `test_sheet_reader.py` 국내 픽스처·읽기·중복키 테스트 갱신
- [x] 전체 138개 테스트 통과