### PR TITLE
feat: 종목코드 컬럼을 TEXT 포맷으로 통일 (정렬 일관화·앞0 보존)

### DIFF
--- a/modules/google_sheets_client.py
+++ b/modules/google_sheets_client.py
@@ -869,6 +869,43 @@ class GoogleSheetsClient:
         return requests
 
     @staticmethod
+    def build_text_format_requests(
+        sheet_id: int,
+        col: Optional[int],
+        start_row: int, end_row: int,
+    ) -> List[Dict[str, Any]]:
+        """지정 컬럼을 TEXT(@) 포맷으로 설정하는 repeatCell 요청 생성 (API 호출 없음)
+
+        종목코드처럼 숫자로 보이지만 텍스트로 다뤄야 하는 컬럼에 사용. TEXT 셀에
+        USER_ENTERED로 값을 쓰면 숫자 자동 변환(우측정렬·앞0 손실)이 일어나지 않는다.
+
+        Args:
+            sheet_id: 시트 ID
+            col: TEXT로 만들 컬럼 (1-based). None이면 빈 리스트 반환.
+            start_row: 시작 행 (1-based)
+            end_row: 종료 행 (1-based, inclusive)
+        """
+        if col is None:
+            return []
+        return [{
+            'repeatCell': {
+                'range': {
+                    'sheetId': sheet_id,
+                    'startRowIndex': start_row - 1,
+                    'endRowIndex': end_row,
+                    'startColumnIndex': col - 1,
+                    'endColumnIndex': col,
+                },
+                'cell': {
+                    'userEnteredFormat': {
+                        'numberFormat': {'type': 'TEXT', 'pattern': '@'}
+                    }
+                },
+                'fields': 'userEnteredFormat.numberFormat',
+            }
+        }]
+
+    @staticmethod
     def build_color_requests(
         sheet_id: int,
         color_ranges: List[Dict[str, Any]],
@@ -937,6 +974,7 @@ class GoogleSheetsClient:
         filter_end_col: int = 9,
         clear_bg_end_row: int = 1000,
         clear_bg_end_col: int = 26,
+        text_format_col: Optional[int] = None,
     ) -> bool:
         """시트 포맷팅(행고정 + 필터 + 배경색초기화)을 1회 batchUpdate로 적용
 
@@ -948,6 +986,7 @@ class GoogleSheetsClient:
             filter_end_col: 필터 종료 열 (1-based, inclusive)
             clear_bg_end_row: 배경색 초기화 마지막 행
             clear_bg_end_col: 배경색 초기화 마지막 열
+            text_format_col: TEXT 포맷으로 만들 컬럼 (1-based, 예: 종목코드). None이면 미적용.
         """
         try:
             sheet_id = await self.get_sheet_id(sheet_name)
@@ -992,6 +1031,13 @@ class GoogleSheetsClient:
                     }
                 },
             ]
+
+            # 종목코드 등 텍스트로 다뤄야 하는 컬럼을 TEXT 포맷으로 (헤더 제외, 2행~)
+            requests.extend(
+                self.build_text_format_requests(
+                    sheet_id, text_format_col, 2, clear_bg_end_row
+                )
+            )
 
             await self._execute_with_retry(
                 lambda: self.service.spreadsheets().batchUpdate(

--- a/modules/sheet_writer.py
+++ b/modules/sheet_writer.py
@@ -103,13 +103,17 @@ class SheetWriter:
 
     async def apply_sheet_formatting(self, sheet_name: str, is_foreign: bool = False):
         """시트에 freeze + filter + 배경색 초기화 적용 (1회 batchUpdate)"""
-        num_cols = len(FOREIGN_HEADERS) if is_foreign else len(DOMESTIC_HEADERS)
+        headers = FOREIGN_HEADERS if is_foreign else DOMESTIC_HEADERS
+        num_cols = len(headers)
+        # 종목코드는 숫자로 보여도 텍스트(정렬 통일·앞0 보존)로 다룬다
+        code_col = headers.index("종목코드") + 1
         await self.client.apply_sheet_formatting_batch(
             sheet_name,
             freeze_row_count=1,
             filter_start_row=1,
             filter_start_col=1,
             filter_end_col=num_cols,
+            text_format_col=code_col,
         )
 
     async def get_existing_keys(self, sheet_name: str, is_foreign: bool = False) -> Set[tuple]:

--- a/modules/summary_generator.py
+++ b/modules/summary_generator.py
@@ -249,6 +249,12 @@ class SummaryGenerator:
         if rows:
             all_rows = [headers] + rows
             end_row = start_row + len(rows)
+            # 종목코드 컬럼(A)을 쓰기 전에 TEXT로 → USER_ENTERED 숫자 변환 방지(정렬·앞0 보존)
+            await self.client.apply_number_format_to_columns(
+                DASHBOARD_SHEET,
+                [{'col': 1, 'pattern': '@', 'type': 'TEXT'}],
+                start_row, end_row,
+            )
             await self.client.batch_update_cells(
                 DASHBOARD_SHEET, {f"A{start_row}:K{end_row}": all_rows}
             )

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -45,6 +45,28 @@ class TestBuildNumberFormatRequests:
         assert result == []
 
 
+class TestBuildTextFormatRequests:
+    """build_text_format_requests() 반환 구조 검증 (종목코드 TEXT 포맷)"""
+
+    def test_returns_text_format_for_column(self):
+        result = GoogleSheetsClient.build_text_format_requests(7, 3, 2, 1000)
+
+        assert len(result) == 1
+        req = result[0]['repeatCell']
+        assert req['range']['sheetId'] == 7
+        assert req['range']['startRowIndex'] == 1   # 2 - 1
+        assert req['range']['endRowIndex'] == 1000   # inclusive
+        assert req['range']['startColumnIndex'] == 2  # col 3 - 1
+        assert req['range']['endColumnIndex'] == 3
+        nf = req['cell']['userEnteredFormat']['numberFormat']
+        assert nf['type'] == 'TEXT'
+        assert nf['pattern'] == '@'
+        assert req['fields'] == 'userEnteredFormat.numberFormat'
+
+    def test_none_column_returns_empty(self):
+        assert GoogleSheetsClient.build_text_format_requests(0, None, 2, 10) == []
+
+
 class TestBuildColorRequests:
     """build_color_requests() 반환 구조 검증"""
 

--- a/tests/test_sheet_reader.py
+++ b/tests/test_sheet_reader.py
@@ -357,6 +357,22 @@ class TestReadAllTrades:
         assert mock_client.get_raw_grid_data.call_count == 1
 
 
+@pytest.mark.asyncio
+async def test_apply_sheet_formatting_marks_domestic_code_column_as_text(writer, mock_client):
+    """국내 시트: 종목코드 컬럼(C=3)을 TEXT 포맷으로 지정하도록 전달"""
+    await writer.apply_sheet_formatting("미래에셋증권_주식2", is_foreign=False)
+    _, kwargs = mock_client.apply_sheet_formatting_batch.call_args
+    assert kwargs["text_format_col"] == DOMESTIC_HEADERS.index("종목코드") + 1  # 3
+
+
+@pytest.mark.asyncio
+async def test_apply_sheet_formatting_marks_foreign_code_column_as_text(writer, mock_client):
+    """해외 시트: 종목코드 컬럼(D=4)을 TEXT 포맷으로 지정하도록 전달"""
+    await writer.apply_sheet_formatting("미래에셋증권_해외계좌", is_foreign=True)
+    _, kwargs = mock_client.apply_sheet_formatting_batch.call_args
+    assert kwargs["text_format_col"] == FOREIGN_HEADERS.index("종목코드") + 1  # 4
+
+
 def test_row_to_trade_domestic_reads_stock_code():
     # 일자, 구분, 종목코드, 종목명, 수량, 단가, 금액, 수수료, 손익, 수익률
     values = [

--- a/tests/test_summary_format.py
+++ b/tests/test_summary_format.py
@@ -34,6 +34,28 @@ def _make_sell_trade(date: str, stock_name: str, amount_krw: float,
     )
 
 
+class TestStockSummaryCodeTextFormat:
+    """종목별 현황: 종목코드 컬럼(A)을 쓰기 전에 TEXT 포맷으로 지정"""
+
+    @pytest.mark.asyncio
+    async def test_code_column_formatted_as_text(self):
+        trades = [_make_buy_trade("2025-01-02", "삼성전자", 1000000)]
+        mock_client = AsyncMock()
+        mock_client.batch_update_cells = AsyncMock(return_value=True)
+        mock_writer = MagicMock()
+        gen = SummaryGenerator(mock_client, mock_writer, sector_classifier=None)
+        gen._dashboard_sheet_id = 0
+
+        await gen._write_stock_summary(trades, start_row=50)
+
+        # 종목코드 컬럼(A=1)에 TEXT 포맷이 적용됐는지
+        calls = mock_client.apply_number_format_to_columns.call_args_list
+        assert any(
+            any(f.get('col') == 1 and f.get('type') == 'TEXT' for f in c.args[1])
+            for c in calls
+        ), "종목코드 컬럼(A)에 TEXT 포맷 적용 호출이 없습니다"
+
+
 class TestGroupConsecutiveRows:
     """연속 행 그룹핑 테스트"""
 


### PR DESCRIPTION
## 문제

종목코드 정렬이 제각각:
- 숫자형 코드(`379780`)는 `USER_ENTERED`로 쓸 때 숫자로 자동 변환 → **우측 정렬**
- 알파벳 포함 코드(`0113D0`, `0060H0`)는 텍스트 유지 → **좌측 정렬**
- `005930`처럼 앞 0이 있는 코드는 숫자 변환 시 **앞 0 손실** 위험

## 원인

데이터를 `USER_ENTERED`로 쓰고 숫자 포맷은 **쓰기 이후**에 적용 → 코드가 이미 숫자로 변환된 뒤라 정렬·앞0을 못 살림.

## 해결

코드 컬럼을 **쓰기 전에** TEXT(`@`) 포맷으로 지정. TEXT 셀에 `USER_ENTERED`로 쓰면 문자열이 그대로 보존되어 좌측 정렬·앞0 모두 유지.

- `GoogleSheetsClient.build_text_format_requests()`: TEXT repeatCell 헬퍼 (정적, 무호출)
- `apply_sheet_formatting_batch(text_format_col=...)`: 시트 포맷 배치에 코드 컬럼 TEXT 포함 (추가 API 호출 없음)
- `SheetWriter.apply_sheet_formatting()`: 국내(C)/해외(D) 종목코드 컬럼 전달 — 매 실행 호출되므로 insert 전에 항상 적용
- `_write_stock_summary()`: 대시보드 종목별 현황 코드 컬럼(A)을 `batch_update_cells` 직전 TEXT로 포맷

## Test plan

- [x] `build_text_format_requests` 반환 구조 테스트 (col/range/TEXT 패턴)
- [x] `apply_sheet_formatting`이 국내=3, 해외=4 컬럼을 `text_format_col`로 전달하는지 검증
- [x] `_write_stock_summary`가 코드 컬럼(A)에 TEXT 포맷을 적용하는지 검증
- [x] 전체 143개 테스트 통과