### PR TITLE
fix: 대시보드에서 숫자로 저장된 종목코드가 누락되는 문제 수정

### DIFF
--- a/modules/sheet_writer.py
+++ b/modules/sheet_writer.py
@@ -441,6 +441,23 @@ def _get_str(cell: Dict, default: str = "") -> str:
     return str(v) if v is not None else default
 
 
+def _get_code(cell: Dict) -> str:
+    """종목코드 추출: 문자열 우선, 숫자로 저장된 경우(TEXT 포맷 이전 행)도 보강.
+
+    종목코드 컬럼을 TEXT로 통일하기 전에 적재된 행은 숫자형 코드(예: 461270)가
+    numberValue로 저장돼 있다. stringValue만 읽으면 누락되므로 numberValue도 처리한다.
+    (앞 0이 있던 코드는 숫자 저장 시점에 이미 0이 잘렸으므로 복구 불가)
+    """
+    ev = cell.get("effectiveValue", {})
+    s = ev.get("stringValue")
+    if s is not None:
+        return str(s)
+    n = ev.get("numberValue")
+    if n is not None:
+        return str(int(n)) if n == int(n) else str(n)
+    return ""
+
+
 def _extract_header_row(data: Dict) -> List[str]:
     """get_sheet_data() 결과에서 1행 헤더를 문자열 리스트로 추출."""
     if not data or "sheets" not in data:
@@ -476,7 +493,7 @@ def _row_to_trade(
                 date=date_val,
                 trade_type=_get_str(values[1]),
                 stock_name=_get_str(values[4]),
-                stock_code=_get_str(values[3]),
+                stock_code=_get_code(values[3]),
                 quantity=_get_num(values[5]),
                 price=_get_num(values[6]),
                 amount=_get_num(values[7]),
@@ -497,7 +514,7 @@ def _row_to_trade(
             return Trade(
                 date=date_val,
                 trade_type=_get_str(values[1]),
-                stock_code=_get_str(values[2]),
+                stock_code=_get_code(values[2]),
                 stock_name=_get_str(values[3]),
                 quantity=_get_num(values[4]),
                 price=_get_num(values[5]),

--- a/tests/test_sheet_reader.py
+++ b/tests/test_sheet_reader.py
@@ -16,6 +16,7 @@ from modules.sheet_writer import (
     OLD_DOMESTIC_HEADERS_V1,
     SheetWriter,
     _extract_header_row,
+    _get_code,
     _get_num,
     _get_str,
     _row_to_trade,
@@ -387,6 +388,32 @@ def test_row_to_trade_domestic_reads_stock_code():
     assert trade.stock_code == "494670"
     assert trade.quantity == 2
     assert trade.price == 28230
+
+
+def test_get_code_handles_string_number_and_empty():
+    # 문자열 코드 (TEXT 셀)
+    assert _get_code({"effectiveValue": {"stringValue": "0113D0"}}) == "0113D0"
+    # 숫자 코드 (TEXT 포맷 이전) → 정수 문자열
+    assert _get_code({"effectiveValue": {"numberValue": 461270}}) == "461270"
+    assert _get_code({"effectiveValue": {"numberValue": 461270.0}}) == "461270"
+    # 빈 셀
+    assert _get_code({}) == ""
+    assert _get_code({"effectiveValue": {}}) == ""
+
+
+def test_row_to_trade_domestic_reads_numeric_stock_code():
+    # TEXT 포맷 도입 이전 행: 종목코드가 숫자(numberValue)로 저장됨.
+    # 시트에는 461270으로 표시되지만 stringValue가 없으므로 읽을 때 누락되면 안 된다.
+    code_cell = {"effectiveValue": {"numberValue": 461270}, "formattedValue": "461270"}
+    values = [
+        _cell("2026-02-13"), _cell("매수"), code_cell,
+        _cell("ACE 26-06 회사채(AA-이상)액티브"), _cell(2), _cell(28230), _cell(56460),
+        _cell(0), _cell(0), _cell(0.0),
+    ]
+    trade = _row_to_trade(values, "미래에셋증권_ISA", is_foreign=False,
+                          date_val="2026-02-13")
+    assert trade is not None
+    assert trade.stock_code == "461270"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 문제

대시보드 종목별 현황에서 같은 종목·계좌가 종목코드 유무로 두 행으로 갈라짐 (예: `461270` 있는 행 / 빈 행). 매매일지 시트에는 코드가 모두 정상 표시됨.

## 원인

`_row_to_trade`가 종목코드를 `_get_str`로 읽는데, `_get_str`은 `effectiveValue.stringValue`만 본다.

- TEXT 포맷 통일(#63) **이후** 적재된 행 → 코드가 텍스트(`stringValue`) → 정상 읽힘
- TEXT 포맷 **이전** 적재된 행 → 숫자형 코드(`461270`)가 `numberValue`로 저장 → `_get_str`이 빈 문자열 반환 → 대시보드에서 누락

시트에는 숫자로 정상 표시되므로 매매일지 자체엔 빈 코드가 없다. 누락은 **읽기 경로**에서만 발생.

집계 키가 `(종목명, 종목코드, 계좌, 통화)`라 코드 유무가 그룹을 갈라 같은 종목·계좌가 중복 행으로 보였다.

## 해결

`_get_code()` 헬퍼 추가 — `stringValue` 우선, 없으면 `numberValue`를 정수 문자열로 변환. 국내(C열)/해외(D열) 종목코드 읽기에 적용. **시트 재생성 없이** 대시보드가 정상화된다.

> 한계: 앞 0이 있던 코드(`005930`)는 숫자로 저장될 때 이미 `5930`으로 0이 잘렸으므로 읽기로는 복구 불가. 해당 종목만 시트 재생성 필요.

## Test plan

- [x] `_get_code` 분기 테스트 (문자열/숫자/실수/빈셀)
- [x] `_row_to_trade`가 numberValue 종목코드를 `"461270"`으로 읽는지 검증
- [x] 전체 145개 테스트 통과