### PR TITLE
fix: 구 포맷 시트 자동 마이그레이션 (섹터/산업 열 삽입)

### DIFF
--- a/internal/sheets/client.go
+++ b/internal/sheets/client.go
@@ -91,6 +91,29 @@ func (c *Client) InvalidateSheetIDCache() {
 	c.sheetIDCache = make(map[string]int64)
 }
 
+// InsertColumns 는 시트의 startIdx(0-based) 위치에 count 개 빈 열을 삽입한다.
+// 기존 데이터는 우측으로 밀리고 값은 보존된다(엑셀 "열 삽입"과 동일).
+func (c *Client) InsertColumns(ctx context.Context, sheetName string, startIdx, count int) error {
+	sheetID, ok, err := c.GetSheetID(ctx, sheetName)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("sheets: 시트를 찾을 수 없습니다: %s", sheetName)
+	}
+	return c.batchUpdate(ctx, []*gsheets.Request{{
+		InsertDimension: &gsheets.InsertDimensionRequest{
+			Range: &gsheets.DimensionRange{
+				SheetId:    sheetID,
+				Dimension:  "COLUMNS",
+				StartIndex: int64(startIdx),
+				EndIndex:   int64(startIdx + count),
+			},
+			InheritFromBefore: false,
+		},
+	}})
+}
+
 // GetRawGridData 는 effectiveValue + formattedValue 를 함께 조회한다. (Python get_raw_grid_data)
 // sheetName 과 rangeA1(예: "A2:O10000")을 받아 내부에서 "sheetName!rangeA1" 로 조합한다.
 func (c *Client) GetRawGridData(ctx context.Context, sheetName, rangeA1 string) (*gsheets.GridData, error) {

--- a/internal/writer/migrate.go
+++ b/internal/writer/migrate.go
@@ -1,0 +1,90 @@
+package writer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// colRun 은 신 헤더 기준 빈 열 삽입 구간(start: 0-based 시작 인덱스, count: 개수).
+type colRun struct {
+	start, count int
+}
+
+// migrationInserts 는 oldHeader 를 newHeader 로 변환하기 위해 삽입할 빈 열 구간들을
+// 계산한다. old 의 모든 컬럼이 new 에 같은 순서로 존재해야 하며(중간에 신규 컬럼만 추가됨),
+// 그렇지 않으면 (nil, false) 를 반환한다.
+//
+// 반환된 run 들은 new 인덱스 기준이며 **왼쪽→오른쪽 순서로** 삽입해야 한다(각 삽입 후
+// 시트의 해당 위치까지가 new 포맷과 일치하므로 다음 run 의 new 인덱스가 그대로 유효하다).
+func migrationInserts(oldHeader, newHeader []string) ([]colRun, bool) {
+	isNew := make([]bool, len(newHeader))
+	oi := 0
+	for ni, col := range newHeader {
+		if oi < len(oldHeader) && oldHeader[oi] == col {
+			oi++ // 기존 컬럼
+		} else {
+			isNew[ni] = true // 신규 삽입 컬럼
+		}
+	}
+	if oi != len(oldHeader) {
+		return nil, false // old 컬럼이 new 에 순서대로 모두 매칭되지 않음
+	}
+
+	var runs []colRun
+	for ni := 0; ni < len(newHeader); ni++ {
+		if !isNew[ni] {
+			continue
+		}
+		start := ni
+		count := 0
+		for ni < len(newHeader) && isNew[ni] {
+			count++
+			ni++
+		}
+		ni-- // for 루프의 ni++ 보정
+		runs = append(runs, colRun{start: start, count: count})
+	}
+	return runs, true
+}
+
+// ensureNewFormat 은 기존 시트가 구 포맷이면 신 포맷으로 자동 마이그레이션한다.
+// 신 포맷/빈 시트/매매일지 아님 → no-op. 시트 헤더만 1회 조회한다.
+func (w *Writer) ensureNewFormat(ctx context.Context, sheetName string) error {
+	headerVals, err := w.client.GetValues(ctx, sheetName+"!A1:Q1")
+	if err != nil {
+		return err
+	}
+	headerRow := extractHeaderRow(headerVals)
+	switch {
+	case headersEqual(headerRow, OldDomesticHeadersV2),
+		headersEqual(headerRow, OldDomesticHeadersV1):
+		return w.migrateSheet(ctx, sheetName, headerRow, DomesticHeaders)
+	case headersEqual(headerRow, OldForeignHeadersV1):
+		return w.migrateSheet(ctx, sheetName, headerRow, ForeignHeaders)
+	}
+	return nil
+}
+
+// migrateSheet 은 구 포맷 시트를 신 포맷으로 자동 변환한다.
+// 종목명 뒤 섹터/산업(국내 V1 은 종목코드까지) 빈 열을 삽입해 기존 데이터를 보존한 채
+// 컬럼을 정렬하고, 헤더를 신 포맷으로 교체한다.
+func (w *Writer) migrateSheet(ctx context.Context, sheetName string, oldHeader, newHeader []string) error {
+	runs, ok := migrationInserts(oldHeader, newHeader)
+	if !ok {
+		return fmt.Errorf("writer: 시트 %s 헤더를 신 포맷으로 매핑 불가", sheetName)
+	}
+	// 왼쪽→오른쪽 순서로 빈 열 삽입(기존 데이터는 오른쪽으로 밀림).
+	for _, r := range runs {
+		if err := w.client.InsertColumns(ctx, sheetName, r.start, r.count); err != nil {
+			return fmt.Errorf("writer: 시트 %s 열 삽입(%d,%d): %w", sheetName, r.start, r.count, err)
+		}
+	}
+	if err := w.client.UpdateCells(ctx, sheetName+"!A1", [][]interface{}{toAnyRow(newHeader)}); err != nil {
+		return fmt.Errorf("writer: 시트 %s 헤더 갱신: %w", sheetName, err)
+	}
+	w.invalidateCache()
+	slog.Info("시트 자동 마이그레이션 완료(섹터/산업 열 삽입)", "sheet", sheetName,
+		"old_cols", len(oldHeader), "new_cols", len(newHeader))
+	return nil
+}

--- a/internal/writer/migrate_test.go
+++ b/internal/writer/migrate_test.go
@@ -1,0 +1,62 @@
+package writer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMigrationInserts(t *testing.T) {
+	tests := []struct {
+		name     string
+		old, new []string
+		want     []colRun
+		wantOK   bool
+	}{
+		{
+			name:   "국내 V2(10) → 신(12): 종목명 뒤 섹터/산업 2열",
+			old:    OldDomesticHeadersV2,
+			new:    DomesticHeaders,
+			want:   []colRun{{start: 4, count: 2}},
+			wantOK: true,
+		},
+		{
+			name:   "해외 V1(15) → 신(17): 종목명 뒤 섹터/산업 2열",
+			old:    OldForeignHeadersV1,
+			new:    ForeignHeaders,
+			want:   []colRun{{start: 5, count: 2}},
+			wantOK: true,
+		},
+		{
+			name:   "국내 V1(9) → 신(12): 종목코드 1열 + 섹터/산업 2열",
+			old:    OldDomesticHeadersV1,
+			new:    DomesticHeaders,
+			want:   []colRun{{start: 2, count: 1}, {start: 4, count: 2}},
+			wantOK: true,
+		},
+		{
+			name:   "이미 신 포맷: 삽입 없음",
+			old:    DomesticHeaders,
+			new:    DomesticHeaders,
+			want:   nil,
+			wantOK: true,
+		},
+		{
+			name:   "호환 불가(구 컬럼이 신에 순서대로 없음)",
+			old:    []string{"엉뚱", "헤더"},
+			new:    DomesticHeaders,
+			want:   nil,
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := migrationInserts(tt.old, tt.new)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("runs = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/writer/reader.go
+++ b/internal/writer/reader.go
@@ -55,11 +55,19 @@ func (w *Writer) ReadAllTrades(ctx context.Context) ([]model.Trade, error) {
 		case headersEqual(headerRow, ForeignHeaders):
 			isForeign = true
 		case headersEqual(headerRow, OldDomesticHeadersV2),
-			headersEqual(headerRow, OldForeignHeadersV1),
 			headersEqual(headerRow, OldDomesticHeadersV1):
-			slog.Warn("시트가 섹터/산업 추가 이전 포맷입니다. 시트를 삭제 후 재실행하거나 "+
-				"종목명 뒤에 '섹터','산업' 컬럼을 수동 삽입하세요. (이번 실행에서는 스킵)", "sheet", sheetName)
-			continue
+			// 구 포맷 → 신 포맷 자동 마이그레이션 후 읽기.
+			if err := w.migrateSheet(ctx, sheetName, headerRow, DomesticHeaders); err != nil {
+				slog.Error("자동 마이그레이션 실패, 스킵", "sheet", sheetName, "err", err)
+				continue
+			}
+			isForeign = false
+		case headersEqual(headerRow, OldForeignHeadersV1):
+			if err := w.migrateSheet(ctx, sheetName, headerRow, ForeignHeaders); err != nil {
+				slog.Error("자동 마이그레이션 실패, 스킵", "sheet", sheetName, "err", err)
+				continue
+			}
+			isForeign = true
 		default:
 			slog.Debug("시트 스킵(매매일지 헤더 불일치)", "sheet", sheetName)
 			continue

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -50,6 +50,10 @@ func (w *Writer) EnsureSheetExists(ctx context.Context, sheetName string, isFore
 	}
 	for _, n := range names {
 		if n == sheetName {
+			// 구 포맷이면 신 포맷으로 자동 마이그레이션(섹터/산업 열 삽입) 후 진행.
+			if err := w.ensureNewFormat(ctx, sheetName); err != nil {
+				return false, err
+			}
 			if err := w.ApplySheetFormatting(ctx, sheetName, isForeign); err != nil {
 				return false, err
 			}


### PR DESCRIPTION
## 배경
섹터/산업 열 추가(PR #67, 국내 12 / 해외 17컬럼) 이후, **기존 구 포맷 시트**(국내 10/9, 해외 15컬럼)에 `InsertTrades`가 헤더 검사 없이 신 포맷 행을 그대로 append 하여 **컬럼이 2칸 어긋나는** 문제가 발생했습니다. reader는 구 포맷을 감지해 스킵만 했고(write/read 비대칭), 그 결과 대시보드도 0건으로 갱신되지 않았습니다.

## 수정 — 자동 마이그레이션
구 포맷 시트를 만나면 **종목명 뒤에 빈 섹터/산업 열을 삽입**하고 헤더를 신 포맷으로 교체합니다. 기존 데이터는 보존되고(엑셀 "열 삽입"과 동일) 섹터/산업 칸만 빈 채 추가되어 모든 행이 정렬됩니다.

- `migrationInserts()` — 구→신 헤더 변환에 필요한 빈 열 삽입 구간 계산 (순수 로직, **TDD**). 국내 V2(10)→12: index 4에 2열, 해외 V1(15)→17: index 5에 2열, 국내 V1(9)→12: 종목코드+섹터/산업.
- `sheets.Client.InsertColumns()` — `InsertDimension` 으로 빈 열 삽입(값 보존, 우측 시프트).
- `Writer.migrateSheet()` / `ensureNewFormat()` — 감지 시 열 삽입 + 헤더 교체.
- `EnsureSheetExists`(쓰기 경로) / `ReadAllTrades`(대시보드 읽기 경로) 가 구 포맷 시 경고+스킵 대신 자동 마이그레이션.

## 실측 검증 (실제 시트)
`make run` 1회로 8개 시트 전부 자동 마이그레이션 확인:
- 국내 7개(10→12), 해외 1개(15→17) 마이그레이션 완료
- 전체 매매일지 읽기 **0 → 6,410건**, 대시보드 완전 갱신(월별/지표/인사이트/추이/종목별/차트)
- 마이그레이션 후 구·신 데이터 모두 12컬럼 정렬 일치 확인

## Test plan
- [x] `TestMigrationInserts` (5케이스: 국내 V2/V1, 해외 V1, 이미 신포맷, 호환 불가)
- [x] `go build ./...` / `go vet ./...` / `go test ./...` 전체 통과
- [x] 실제 스프레드시트 8개 시트 마이그레이션 + 대시보드 갱신 E2E 확인