### PR TITLE
feat(bizcat): 산업을 표준산업분류로 변경 (커버리지 개선)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ internal/
 2. **파서 감지**: CSV 헤더를 읽어 파서 자동 선택
 3. **파싱**: 증권사 형식에 맞춰 Trade 객체 리스트 생성
 4. **종목코드 보강**: 국내 거래 중 종목코드가 빈 항목을 KRX 마스터에서 조회해 채움
-4b. **섹터/산업 보강**: 국내 거래에 KIS 지수업종(중분류=섹터, 소분류=산업) 조회해 채움 (`internal/bizcat`, 해외는 공란)
+4b. **섹터/산업 보강**: 국내 거래에 KIS 조회로 채움 — 섹터=지수업종 중분류, 산업=표준산업분류 (`internal/bizcat`, 해외는 공란)
 5. **시트 확인**: 시트가 없으면 자동 생성 + 헤더 삽입
 6. **중복 필터**: 기존 시트 데이터와 비교하여 중복 제거
 7. **데이터 삽입**: 신규 거래 일괄 삽입 + 숫자/통화 포맷 적용 (거래 시트 날짜별 배경색은 현재 미적용)
@@ -69,7 +69,7 @@ internal/
 - `Trade` struct (Sector/Industry 포함) + `ToDomesticRow`(12컬럼)/`ToForeignRow`(17컬럼)/`ToSheetRow` + `DuplicateKey`(DupKey; 섹터/산업 미포함)
 
 **internal/bizcat** (`resolver.go`):
-- KIS `Domestic.SearchStockInfo(code,"300")` → 섹터=지수업종 **중분류**(`IdxBztpMclsCdName`, 예 "전기,전자"), 산업=**소분류**(`IdxBztpSclsCdName`). ⚠️ 대분류는 "시가총액규모"라 미사용.
+- KIS `Domestic.SearchStockInfo(code,"300")` → 섹터=지수업종 **중분류**(`IdxBztpMclsCdName`, 예 "전기,전자"), 산업=**표준산업분류**(`StdIdstClsfCdName`, 예 "의료용 기기 제조업"). ⚠️ 대분류는 "시가총액규모"라 미사용. 소분류(`IdxBztpSclsCdName`)는 중분류와 동일값이라 미사용. 표준산업분류는 지수업종이 비는 일반 종목(클래시스·솔루엠 등)도 채워져 커버리지가 넓다(ETF·일부 종목은 둘 다 공란).
 - 영구 캐시 `config/bizcat_cache.json`, lazy `kis.NewClientFromEnv()`. KIS 키 없거나 실패 시 빈 값(회복력).
 - atj 는 `ensureKISFileToken`(main.go)으로 **파일 토큰 강제** — env가 redis 라도 Redis 의존 없이 동작.
 
@@ -136,7 +136,7 @@ logging:
 국내계좌 시트는 **12컬럼**: 일자, 구분, 종목코드, 종목명, **섹터, 산업**, 수량, 단가, 금액,
 수수료, 손익금액, 수익률(%). 해외계좌 시트는 **17컬럼**(종목명 뒤 섹터/산업, 해외는 공란).
 - 종목코드: CSV에 없으면 KRX 마스터(`internal/symbol`)에서 조회.
-- 섹터/산업: 국내만 KIS 지수업종(`internal/bizcat`, 중분류/소분류)에서 조회. 해외 공란.
+- 섹터/산업: 국내만 KIS 조회(`internal/bizcat`, 섹터=지수업종 중분류 / 산업=표준산업분류)로 채움. 해외 공란.
 
 **기존 시트 마이그레이션**: 섹터/산업(또는 종목코드) 컬럼 도입 이전 포맷(10/15/9컬럼) 시트는
 헤더 불일치로 **경고 로그와 함께 스킵**됩니다(자동 변환 안 함). 시트를 삭제 후 재실행하거나

--- a/internal/bizcat/resolver.go
+++ b/internal/bizcat/resolver.go
@@ -101,9 +101,18 @@ func kisFetch() func(string) (string, string, error) {
 		if err != nil {
 			return "", "", err
 		}
-		// 주의: 대분류(IdxBztpLclsCdName)는 "시가총액규모"라 업종이 아니다(예 "시가총액규모대").
-		// 실제 업종은 중분류(예 "전기,전자"), 소분류가 더 세부다.
-		// → 섹터=중분류, 산업=소분류.
-		return info.IdxBztpMclsCdName, info.IdxBztpSclsCdName, nil
+		sector, industry := pickSectorIndustry(info.IdxBztpMclsCdName, info.StdIdstClsfCdName)
+		return sector, industry, nil
 	}
+}
+
+// pickSectorIndustry 는 KIS 주식기본조회 업종 필드에서 섹터/산업을 선택한다.
+//
+//   - 섹터  = 지수업종 중분류(idx_bztp_mcls_cd_name, 예 "전기,전자"/"서비스업").
+//     대분류는 "시가총액규모"라 업종이 아니므로 미사용. 지수업종 미분류 종목/ETF 는 빈값.
+//   - 산업  = 표준산업분류(std_idst_clsf_cd_name, 예 "의료용 기기 제조업").
+//     지수업종(중/소분류)이 비는 일반 종목(클래시스·솔루엠 등)도 표준산업분류는 채워져
+//     커버리지가 넓다. (소분류 idx_bztp_scls_cd_name 은 중분류와 동일값이라 미사용.)
+func pickSectorIndustry(idxBztpMcls, stdIdstClsf string) (sector, industry string) {
+	return idxBztpMcls, stdIdstClsf
 }

--- a/internal/bizcat/resolver_test.go
+++ b/internal/bizcat/resolver_test.go
@@ -44,6 +44,25 @@ func TestResolve_EmptyCodeOrErrorReturnsBlank(t *testing.T) {
 	assert.Equal(t, "", i)
 }
 
+// 섹터 = 지수업종 중분류, 산업 = 표준산업분류(일반 종목 커버리지가 넓음).
+// 지수업종이 비어도(클래시스/솔루엠 등) 표준산업분류로 산업은 채워져야 한다.
+func TestPickSectorIndustry(t *testing.T) {
+	// 대형주: 둘 다 채워짐
+	s, i := pickSectorIndustry("전기,전자", "통신 및 방송 장비 제조업")
+	assert.Equal(t, "전기,전자", s)
+	assert.Equal(t, "통신 및 방송 장비 제조업", i)
+
+	// 지수업종 미분류 일반 종목(클래시스): 섹터 빈값이지만 산업은 표준산업분류로 채워짐
+	s, i = pickSectorIndustry("", "의료용 기기 제조업")
+	assert.Equal(t, "", s)
+	assert.Equal(t, "의료용 기기 제조업", i)
+
+	// ETF: 둘 다 빈값
+	s, i = pickSectorIndustry("", "")
+	assert.Equal(t, "", s)
+	assert.Equal(t, "", i)
+}
+
 func TestCacheSaveLoad_Roundtrip_PreservesKorean(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bizcat_cache.json")


### PR DESCRIPTION
## 배경
섹터/산업이 대부분 빈값인 원인을 KIS `search-stock-info` 실측으로 분석했습니다.

| 종목 | 중분류(섹터) | 소분류 | 표준산업분류 |
|---|---|---|---|
| 삼성전자 | 전기,전자 | 전기,전자 | 통신 및 방송 장비 제조업 |
| NAVER | 서비스업 | 서비스업 | 자료처리, 호스팅… |
| 클래시스 | (빈값) | (빈값) | **의료용 기기 제조업** |
| 솔루엠 | (빈값) | (빈값) | **전자부품 제조업** |
| KODEX 반도체(ETF) | (빈값) | (빈값) | (빈값) |

발견:
1. **중분류=소분류 동일값** → 섹터/산업 두 열이 중복.
2. 지수업종(중/소분류)은 **대형주만** 채워지고 다수 일반 종목·ETF 는 빈값.
3. **표준산업분류**(`std_idst_clsf_cd_name`)는 지수업종이 비는 일반 종목도 채워져 커버리지가 넓다.

## 변경
- **산업** = 지수업종 소분류 → **표준산업분류**(`StdIdstClsfCdName`). 섹터는 중분류 유지.
- `pickSectorIndustry()` 순수 함수로 매핑 추출 + TDD.

## 효과 (실측 재조회)
- 클래시스 → 산업="의료용 기기 제조업" ✅ (이전 빈값)
- 솔루엠 → 산업="전자부품 제조업" ✅
- ETF·지수 미편입 종목은 불가피하게 공란(KIS 미제공)

## 알려진 한계 (별개 follow-up)
bizcat 이 KIS 를 초당 제한보다 빠르게 호출해 일부 종목이 `EGW00201`(초당 거래건수 초과)로 한 실행에서 누락될 수 있음(다음 실행에 채워짐). rate limit 페이싱 + 실패 negative-cache 는 후속 개선 대상.

## Test plan
- [x] `TestPickSectorIndustry` (대형주/지수 미분류 종목/ETF 3케이스)
- [x] `go build ./...` / `go vet ./...` / `go test ./...` 전체 통과
- [x] 실측: 캐시 비우고 재조회 → 클래시스/솔루엠 산업 채워짐 확인