### PR TITLE
feat(bizcat): 섹터를 InquirePrice 업종 한글명(bstp_kor_isnm)으로 변경

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ internal/
 ├── parser   - Parser 인터페이스 + registry(DetectParser) + mirae/hankook
 │             (readCSVRows 가 CP949/UTF-8 네이티브 디코딩)
 ├── symbol   - KRX .mst → 종목코드 (fwf + cp949, 7일 캐시)
-├── bizcat   - KIS 지수업종 → 섹터/산업 (SearchStockInfo, 영구 캐시) — 거래행 섹터/산업 열용
+├── bizcat   - KIS 업종 조회 → 섹터/산업 (InquirePrice + SearchStockInfo, 영구 캐시) — 거래행 섹터/산업 열용
 ├── sector   - OpenAI 섹터 분류 (go-openai, JSON 캐시) — 요약 "섹터별 투자비중"용 (bizcat과 별개)
 ├── sheets   - Google Sheets v4 래퍼 (값/포맷/색상/필터/차트 + 레이트리밋 재시도)
 ├── writer   - 시트 생성/중복필터/삽입 + ReadAllTrades
@@ -49,7 +49,7 @@ internal/
 2. **파서 감지**: CSV 헤더를 읽어 파서 자동 선택
 3. **파싱**: 증권사 형식에 맞춰 Trade 객체 리스트 생성
 4. **종목코드 보강**: 국내 거래 중 종목코드가 빈 항목을 KRX 마스터에서 조회해 채움
-4b. **섹터/산업 보강**: 국내 거래에 KIS 조회로 채움 — 섹터=지수업종 중분류, 산업=표준산업분류 (`internal/bizcat`, 해외는 공란)
+4b. **섹터/산업 보강**: 국내 거래에 KIS 조회로 채움 — 섹터=InquirePrice 업종 한글명(bstp_kor_isnm), 산업=표준산업분류 (`internal/bizcat`, 해외는 공란)
 5. **시트 확인**: 시트가 없으면 자동 생성 + 헤더 삽입
 6. **중복 필터**: 기존 시트 데이터와 비교하여 중복 제거
 7. **데이터 삽입**: 신규 거래 일괄 삽입 + 숫자/통화 포맷 적용 (거래 시트 날짜별 배경색은 현재 미적용)
@@ -69,7 +69,9 @@ internal/
 - `Trade` struct (Sector/Industry 포함) + `ToDomesticRow`(12컬럼)/`ToForeignRow`(17컬럼)/`ToSheetRow` + `DuplicateKey`(DupKey; 섹터/산업 미포함)
 
 **internal/bizcat** (`resolver.go`):
-- KIS `Domestic.SearchStockInfo(code,"300")` → 섹터=지수업종 **중분류**(`IdxBztpMclsCdName`, 예 "전기,전자"), 산업=**표준산업분류**(`StdIdstClsfCdName`, 예 "의료용 기기 제조업"). ⚠️ 대분류는 "시가총액규모"라 미사용. 소분류(`IdxBztpSclsCdName`)는 중분류와 동일값이라 미사용. 표준산업분류는 지수업종이 비는 일반 종목(클래시스·솔루엠 등)도 채워져 커버리지가 넓다(ETF·일부 종목은 둘 다 공란).
+- 섹터 = `Domestic.InquirePrice(code)` 의 **업종 한글명**(`BstpKorIsnm`/bstp_kor_isnm, 예 "전기·전자"/"IT 서비스"/"의료·정밀기기"). 일반 종목 커버리지가 가장 넓고(지수업종 중분류는 대형주만 채워짐) moneyflow `sector_detail` 과 동일 소스. ETF 는 "ETF(실물복제/수익증권)" 라벨.
+- 산업 = `Domestic.SearchStockInfo(code,"300")` 의 **표준산업분류**(`StdIdstClsfCdName`, 예 "의료용 기기 제조업"). 일반 종목은 채워지고 ETF 는 공란. ⚠️ 지수업종(대/중/소분류)은 커버리지가 낮아 미사용.
+- 즉 코드당 InquirePrice + SearchStockInfo **2회 호출**. (rate limit 페이싱은 향후 개선 대상.)
 - 영구 캐시 `config/bizcat_cache.json`, lazy `kis.NewClientFromEnv()`. KIS 키 없거나 실패 시 빈 값(회복력).
 - atj 는 `ensureKISFileToken`(main.go)으로 **파일 토큰 강제** — env가 redis 라도 Redis 의존 없이 동작.
 
@@ -136,7 +138,7 @@ logging:
 국내계좌 시트는 **12컬럼**: 일자, 구분, 종목코드, 종목명, **섹터, 산업**, 수량, 단가, 금액,
 수수료, 손익금액, 수익률(%). 해외계좌 시트는 **17컬럼**(종목명 뒤 섹터/산업, 해외는 공란).
 - 종목코드: CSV에 없으면 KRX 마스터(`internal/symbol`)에서 조회.
-- 섹터/산업: 국내만 KIS 조회(`internal/bizcat`, 섹터=지수업종 중분류 / 산업=표준산업분류)로 채움. 해외 공란.
+- 섹터/산업: 국내만 KIS 조회(`internal/bizcat`, 섹터=InquirePrice 업종 한글명 / 산업=표준산업분류)로 채움. 해외 공란.
 
 **기존 시트 마이그레이션**: 섹터/산업(또는 종목코드) 컬럼 도입 이전 포맷(10/15/9컬럼) 시트는
 헤더 불일치로 **경고 로그와 함께 스킵**됩니다(자동 변환 안 함). 시트를 삭제 후 재실행하거나

--- a/internal/bizcat/resolver.go
+++ b/internal/bizcat/resolver.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	kis "github.com/kenshin579/korea-investment-stock"
+	"github.com/kenshin579/korea-investment-stock/domestic"
 )
 
 type entry struct {
@@ -97,22 +98,27 @@ func kisFetch() func(string) (string, string, error) {
 		return func(string) (string, string, error) { return "", "", nil }
 	}
 	return func(code string) (string, string, error) {
-		info, err := client.Domestic.SearchStockInfo(context.Background(), code, "300")
+		ctx := context.Background()
+		price, err := client.Domestic.InquirePrice(ctx, code)
 		if err != nil {
 			return "", "", err
 		}
-		sector, industry := pickSectorIndustry(info.IdxBztpMclsCdName, info.StdIdstClsfCdName)
+		info, err := client.Domestic.SearchStockInfo(ctx, code, "300")
+		if err != nil {
+			return "", "", err
+		}
+		sector, industry := extractSectorIndustry(price, info)
 		return sector, industry, nil
 	}
 }
 
-// pickSectorIndustry 는 KIS 주식기본조회 업종 필드에서 섹터/산업을 선택한다.
+// extractSectorIndustry 는 KIS 응답에서 섹터/산업을 추출한다.
 //
-//   - 섹터  = 지수업종 중분류(idx_bztp_mcls_cd_name, 예 "전기,전자"/"서비스업").
-//     대분류는 "시가총액규모"라 업종이 아니므로 미사용. 지수업종 미분류 종목/ETF 는 빈값.
-//   - 산업  = 표준산업분류(std_idst_clsf_cd_name, 예 "의료용 기기 제조업").
-//     지수업종(중/소분류)이 비는 일반 종목(클래시스·솔루엠 등)도 표준산업분류는 채워져
-//     커버리지가 넓다. (소분류 idx_bztp_scls_cd_name 은 중분류와 동일값이라 미사용.)
-func pickSectorIndustry(idxBztpMcls, stdIdstClsf string) (sector, industry string) {
-	return idxBztpMcls, stdIdstClsf
+//   - 섹터  = InquirePrice 의 업종 한글명(bstp_kor_isnm, 예 "전기·전자"/"IT 서비스"/"의료·정밀기기").
+//     지수업종 중분류가 비는 일반 종목(클래시스·솔루엠 등)도 채워져 커버리지가 가장 넓다.
+//     ETF 는 "ETF(실물복제/수익증권)" 라벨이 들어온다. moneyflow 의 sector_detail 과 동일 소스.
+//   - 산업  = search-stock-info 의 표준산업분류(std_idst_clsf_cd_name, 예 "의료용 기기 제조업").
+//     일반 종목은 채워지고 ETF 는 빈값.
+func extractSectorIndustry(price *domestic.Price, info *domestic.StockInfo) (sector, industry string) {
+	return price.BstpKorIsnm, info.StdIdstClsfCdName
 }

--- a/internal/bizcat/resolver_test.go
+++ b/internal/bizcat/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kenshin579/korea-investment-stock/domestic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,22 +45,31 @@ func TestResolve_EmptyCodeOrErrorReturnsBlank(t *testing.T) {
 	assert.Equal(t, "", i)
 }
 
-// 섹터 = 지수업종 중분류, 산업 = 표준산업분류(일반 종목 커버리지가 넓음).
-// 지수업종이 비어도(클래시스/솔루엠 등) 표준산업분류로 산업은 채워져야 한다.
-func TestPickSectorIndustry(t *testing.T) {
+// 섹터 = InquirePrice 업종 한글명(bstp_kor_isnm), 산업 = 표준산업분류(std_idst_clsf_cd_name).
+// bstp_kor_isnm 은 지수업종이 비는 일반 종목(클래시스 등)도 채워져 커버리지가 넓다.
+func TestExtractSectorIndustry(t *testing.T) {
 	// 대형주: 둘 다 채워짐
-	s, i := pickSectorIndustry("전기,전자", "통신 및 방송 장비 제조업")
-	assert.Equal(t, "전기,전자", s)
-	assert.Equal(t, "통신 및 방송 장비 제조업", i)
+	s, i := extractSectorIndustry(
+		&domestic.Price{BstpKorIsnm: "전기·전자"},
+		&domestic.StockInfo{StdIdstClsfCdName: "반도체 제조업"},
+	)
+	assert.Equal(t, "전기·전자", s)
+	assert.Equal(t, "반도체 제조업", i)
 
-	// 지수업종 미분류 일반 종목(클래시스): 섹터 빈값이지만 산업은 표준산업분류로 채워짐
-	s, i = pickSectorIndustry("", "의료용 기기 제조업")
-	assert.Equal(t, "", s)
+	// 지수업종 미분류 일반 종목(클래시스)도 bstp_kor_isnm 으로 섹터가 채워짐
+	s, i = extractSectorIndustry(
+		&domestic.Price{BstpKorIsnm: "의료·정밀기기"},
+		&domestic.StockInfo{StdIdstClsfCdName: "의료용 기기 제조업"},
+	)
+	assert.Equal(t, "의료·정밀기기", s)
 	assert.Equal(t, "의료용 기기 제조업", i)
 
-	// ETF: 둘 다 빈값
-	s, i = pickSectorIndustry("", "")
-	assert.Equal(t, "", s)
+	// ETF: bstp_kor_isnm 은 "ETF(...)", 표준산업분류는 빈값
+	s, i = extractSectorIndustry(
+		&domestic.Price{BstpKorIsnm: "ETF(실물복제/수익증권)"},
+		&domestic.StockInfo{},
+	)
+	assert.Equal(t, "ETF(실물복제/수익증권)", s)
 	assert.Equal(t, "", i)
 }
 


### PR DESCRIPTION
## 배경
KIS 3개 업종 필드의 커버리지를 실측 비교했습니다.

| 종목 | `bstp_kor_isnm`(InquirePrice) | 중분류(현행 섹터) | 표준산업분류(산업) |
|---|---|---|---|
| 삼성전자 | 전기·전자 | 전기,전자 | 통신 및 방송 장비 제조업 |
| NAVER | IT 서비스 | 서비스업 | 자료처리, 호스팅… |
| 알테오젠(KOSDAQ) | 일반서비스 | **(빈값)** | 자연과학 및 공학 연구개발업 |
| 클래시스(KOSDAQ) | 의료·정밀기기 | **(빈값)** | 의료용 기기 제조업 |
| 솔루엠 | 전기·전자 | **(빈값)** | 전자부품 제조업 |
| KODEX 반도체(ETF) | ETF(실물복제/수익증권) | (빈값) | (빈값) |

**`bstp_kor_isnm` 이 섹터로 압도적 우수**: 일반 종목 100% 커버(중분류는 대형주만), 간결한 라벨, ETF 식별. 게다가 **moneyflow `stock_meta_kr.sector_detail` 과 동일 소스**라 두 프로젝트 일관성도 확보됩니다.

## 변경
- **섹터** = 지수업종 중분류 → `InquirePrice.BstpKorIsnm`. **산업**은 표준산업분류 유지.
- `extractSectorIndustry(*domestic.Price, *domestic.StockInfo)` 로 추출 + TDD.
- `kisFetch` 가 InquirePrice + SearchStockInfo **2회 호출**(코드당).

## 효과 (실측 재조회)
- 클래시스 → 섹터="의료·정밀기기"(이전 빈값) / 산업="의료용 기기 제조업" ✅
- 솔루엠 → 섹터="전기·전자" / 산업="전자부품 제조업" ✅
- ETF → 섹터="ETF(실물복제/수익증권)" / 산업="" (식별됨)

## 알려진 한계 (follow-up #2)
코드당 2회 호출이라 `EGW00201`(초당 거래건수 초과) 빈도가 늘어 일부 종목이 한 실행에서 누락될 수 있음(다음 실행에 채워짐). **rate limit 페이싱**으로 해결 예정.

## Test plan
- [x] `TestExtractSectorIndustry` (대형주/KOSDAQ 일반/ETF 3케이스, 구조체 필드 추출 검증)
- [x] `go build/vet/test ./...` 전체 통과
- [x] 실측: 캐시 비우고 재조회 → 클래시스/솔루엠 섹터 채워짐 확인