### PR TITLE
feat(bizcat): ETF 섹터 라벨을 짧게 "ETF" 로 정규화

### DIFF
--- a/internal/bizcat/resolver.go
+++ b/internal/bizcat/resolver.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 
 	kis "github.com/kenshin579/korea-investment-stock"
@@ -120,5 +121,10 @@ func kisFetch() func(string) (string, string, error) {
 //   - 산업  = search-stock-info 의 표준산업분류(std_idst_clsf_cd_name, 예 "의료용 기기 제조업").
 //     일반 종목은 채워지고 ETF 는 빈값.
 func extractSectorIndustry(price *domestic.Price, info *domestic.StockInfo) (sector, industry string) {
-	return price.BstpKorIsnm, info.StdIdstClsfCdName
+	sector = price.BstpKorIsnm
+	// ETF 는 "ETF(실물복제/수익증권)" 등 긴 라벨로 오므로 짧게 "ETF" 로 정규화.
+	if strings.HasPrefix(sector, "ETF") {
+		sector = "ETF"
+	}
+	return sector, info.StdIdstClsfCdName
 }

--- a/internal/bizcat/resolver_test.go
+++ b/internal/bizcat/resolver_test.go
@@ -64,12 +64,12 @@ func TestExtractSectorIndustry(t *testing.T) {
 	assert.Equal(t, "의료·정밀기기", s)
 	assert.Equal(t, "의료용 기기 제조업", i)
 
-	// ETF: bstp_kor_isnm 은 "ETF(...)", 표준산업분류는 빈값
+	// ETF: bstp_kor_isnm "ETF(실물복제/수익증권)" → 섹터는 짧게 "ETF" 로 정규화, 산업 빈값
 	s, i = extractSectorIndustry(
 		&domestic.Price{BstpKorIsnm: "ETF(실물복제/수익증권)"},
 		&domestic.StockInfo{},
 	)
-	assert.Equal(t, "ETF(실물복제/수익증권)", s)
+	assert.Equal(t, "ETF", s)
 	assert.Equal(t, "", i)
 }
 


### PR DESCRIPTION
## 배경
섹터를 `InquirePrice.BstpKorIsnm` 으로 바꾼 뒤(#70), ETF 는 "ETF(실물복제/수익증권)" 같은 긴 라벨이 섹터 칸에 들어갔다. CSV 가 ETF 위주라 섹터 열이 이 긴 라벨로 채워져 가독성이 떨어졌다.

## 변경
- `extractSectorIndustry`: 섹터가 "ETF" 로 시작하면 짧게 `"ETF"` 로 정규화.

## 효과 (실측)
- KODEX 반도체 / KODEX AI전력 / TIGER 200 건설 → 섹터="ETF" ✅
- 일반 종목(클래시스="의료·정밀기기", 솔루엠="전기·전자")은 영향 없음

## Test plan
- [x] `TestExtractSectorIndustry` ETF 케이스 → "ETF" 기대로 갱신
- [x] `go build/vet/test ./...` 전체 통과
- [x] 실측 재조회로 ETF="ETF" 확인