### PR TITLE
feat(bizcat): KIS 호출 rate-limit 페이싱 + 실패 negative-cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ internal/
 **internal/bizcat** (`resolver.go`):
 - 섹터 = `Domestic.InquirePrice(code)` 의 **업종 한글명**(`BstpKorIsnm`/bstp_kor_isnm, 예 "전기·전자"/"IT 서비스"/"의료·정밀기기"). 일반 종목 커버리지가 가장 넓고(지수업종 중분류는 대형주만 채워짐) moneyflow `sector_detail` 과 동일 소스. ETF 는 "ETF(실물복제/수익증권)" 라벨.
 - 산업 = `Domestic.SearchStockInfo(code,"300")` 의 **표준산업분류**(`StdIdstClsfCdName`, 예 "의료용 기기 제조업"). 일반 종목은 채워지고 ETF 는 공란. ⚠️ 지수업종(대/중/소분류)은 커버리지가 낮아 미사용.
-- 즉 코드당 InquirePrice + SearchStockInfo **2회 호출**. (rate limit 페이싱은 향후 개선 대상.)
+- 즉 코드당 InquirePrice + SearchStockInfo **2회 호출**. KIS 초당 제한(EGW00201) 회피를 위해 `WithRateLimit(kisCallsPerSec=4)` 로 호출을 페이싱하고, 같은 실행 내 실패 코드는 negative-cache(`failed`, 비영구)로 재조회를 막는다. 성공 결과는 `config/bizcat_cache.json` 에 영구 캐시(실행 간 유지).
 - 영구 캐시 `config/bizcat_cache.json`, lazy `kis.NewClientFromEnv()`. KIS 키 없거나 실패 시 빈 값(회복력).
 - atj 는 `ensureKISFileToken`(main.go)으로 **파일 토큰 강제** — env가 redis 라도 Redis 의존 없이 동작.
 

--- a/internal/bizcat/resolver.go
+++ b/internal/bizcat/resolver.go
@@ -22,6 +22,7 @@ type entry struct {
 type Resolver struct {
 	mu        sync.Mutex
 	cache     map[string]entry
+	failed    map[string]bool // 이번 실행에서 실패한 코드(negative cache, 비영구)
 	cachePath string
 	fetch     func(code string) (sector, industry string, err error)
 	dirty     bool
@@ -54,11 +55,18 @@ func (r *Resolver) Resolve(code string) (string, string) {
 	if e, ok := r.cache[code]; ok {
 		return e.Sector, e.Industry
 	}
+	if r.failed[code] {
+		return "", "" // 이번 실행에서 이미 실패 → 재조회 안 함
+	}
 	if r.fetch == nil {
 		r.fetch = kisFetch()
 	}
 	sector, industry, err := r.fetch(code)
 	if err != nil {
+		if r.failed == nil {
+			r.failed = map[string]bool{}
+		}
+		r.failed[code] = true
 		slog.Warn("업종 조회 실패, 빈 값 처리", "code", code, "err", err)
 		return "", ""
 	}
@@ -92,8 +100,13 @@ func (r *Resolver) saveCache() error {
 	return enc.Encode(r.cache)
 }
 
+// kisCallsPerSec 는 bizcat 업종 조회의 KIS 호출 빈도 상한.
+// 코드당 2회 호출(InquirePrice + SearchStockInfo)이라 SDK 기본(15/s)에선 초당 제한
+// (EGW00201)에 걸린다. 보수적으로 낮춰 한 실행에 빠짐없이 채워지도록 한다.
+const kisCallsPerSec = 4
+
 func kisFetch() func(string) (string, string, error) {
-	client, err := kis.NewClientFromEnv()
+	client, err := kis.NewClientFromEnv(kis.WithRateLimit(kisCallsPerSec))
 	if err != nil {
 		slog.Warn("KIS 클라이언트 생성 실패, 업종 보강 비활성화", "err", err)
 		return func(string) (string, string, error) { return "", "", nil }

--- a/internal/bizcat/resolver_test.go
+++ b/internal/bizcat/resolver_test.go
@@ -35,6 +35,21 @@ func TestResolve_MissCallsFetchAndCaches(t *testing.T) {
 	assert.Equal(t, 1, calls)
 }
 
+// 같은 실행 내에서 한 번 실패한 코드는 재조회하지 않는다(negative cache).
+// (영구 캐시엔 저장 안 함 — 다음 실행에는 다시 시도해야 하므로.)
+func TestResolve_NegativeCacheSkipsRefetchOnError(t *testing.T) {
+	calls := 0
+	r := &Resolver{cache: map[string]entry{}, fetch: func(string) (string, string, error) {
+		calls++
+		return "", "", assert.AnError
+	}}
+	s, i := r.Resolve("999999") // 1회차: fetch 실패
+	assert.Equal(t, "", s)
+	assert.Equal(t, "", i)
+	r.Resolve("999999") // 2회차: negative cache 로 재조회 안 함
+	assert.Equal(t, 1, calls, "실패 코드는 같은 실행 내 1회만 호출")
+}
+
 func TestResolve_EmptyCodeOrErrorReturnsBlank(t *testing.T) {
 	r := &Resolver{cache: map[string]entry{}, fetch: func(string) (string, string, error) { return "", "", assert.AnError }}
 	s, i := r.Resolve("")


### PR DESCRIPTION
## 배경
섹터를 `InquirePrice.BstpKorIsnm` 으로 바꾸면서 코드당 2회 호출(InquirePrice + SearchStockInfo)이 되었고, SDK 기본 15/s 에선 일부 종목이 `EGW00201`(초당 거래건수 초과)로 한 실행에서 누락됐다(다음 실행에 채워지긴 함).

## 변경
- **① 페이싱**: `NewClientFromEnv(WithRateLimit(kisCallsPerSec=4))` 로 KIS 호출을 4/s 로 제한.
- **② negative-cache**: 같은 실행 내 실패한 코드는 재조회하지 않음(`Resolver.failed`, **비영구** — 영구 캐시엔 저장하지 않아 다음 실행엔 다시 시도). 같은 코드가 여러 거래에 반복될 때 실패 재시도 낭비를 막는다.

> 참고: 성공 결과의 티커별 캐싱은 기존 `config/bizcat_cache.json`(영구, 실행 간 유지)이 이미 담당. SDK 자체엔 REST 응답 캐시가 없다(토큰/마스터/approval-key 캐시만).

## 실측 효과
- 캐시 비우고 `make dry`: **EGW00201 0건**(이전 2건), CSV 19개 고유 종목 **전부 섹터 채움**, 13초.

## Test plan
- [x] `TestResolve_NegativeCacheSkipsRefetchOnError` (실패 코드 같은 실행 내 1회만 호출)
- [x] `go build/vet/test ./...` 전체 통과
- [x] 실측: EGW00201 0건 확인