### PR TITLE
feat(bizcat): 기존 시트 행 섹터/산업 백필 (--backfill-sectors)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Auto Trading Journal은 증권사별 CSV 파일을 파싱하여 구글 시트에
 # 실행 (config/config.yaml + env GOOGLE_SPREADSHEET_ID / SERVICE_ACCOUNT_PATH 필요)
 make run                 # = go run ./cmd/atj --log-level INFO
 make dry                 # 드라이런 (시트 미반영)
+make backfill-sectors    # 기존 국내 시트 행의 섹터/산업 열 일괄 채움(1회용)
 go run ./cmd/atj --dry-run --log-level DEBUG
 
 # 빌드 / 테스트

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run dry build test vet fmt
+.PHONY: run dry backfill-sectors build test vet fmt
 
 # 매매일지 실행 (Go)
 run:
@@ -7,6 +7,10 @@ run:
 # 드라이런 (시트 미반영)
 dry:
 	go run ./cmd/atj --dry-run --log-level DEBUG
+
+# 기존 국내 시트 행의 섹터/산업 열 일괄 채움 (1회용)
+backfill-sectors:
+	go run ./cmd/atj --backfill-sectors --log-level INFO
 
 # 바이너리 빌드
 build:

--- a/cmd/atj/main.go
+++ b/cmd/atj/main.go
@@ -253,6 +253,16 @@ func (p *processor) processFile(ctx context.Context, f csvFile) ([]model.Trade, 
 }
 
 // run 은 메인 실행: CSV 스캔 → 파일별 처리 → 대시보드 갱신. (Python run)
+// backfillSectors 는 기존 국내 시트 행의 섹터/산업 열을 일괄 채운다(1회용).
+func (p *processor) backfillSectors(ctx context.Context) error {
+	slog.Info("=== 섹터/산업 백필 시작 (기존 행 갱신) ===")
+	defer slog.Info("스크립트 실행 완료")
+	if p.bizcatStore != nil {
+		defer p.bizcatStore.Save()
+	}
+	return p.writer.BackfillSectors(ctx, p.bizcatRes.Resolve)
+}
+
 func (p *processor) run(ctx context.Context) error {
 	slog.Info("=== 매매일지 구글 시트 입력 시작 (v2) ===")
 	defer slog.Info("스크립트 실행 완료")
@@ -338,6 +348,7 @@ func ensureKISFileToken() {
 
 func main() {
 	dryRun := flag.Bool("dry-run", false, "실제 데이터 입력 없이 시뮬레이션만 수행합니다.")
+	backfill := flag.Bool("backfill-sectors", false, "기존 국내 시트 행의 섹터/산업 열을 일괄 채웁니다(1회용).")
 	logLevel := flag.String("log-level", "INFO", "로그 레벨을 설정합니다 (DEBUG/INFO/WARNING/ERROR, 기본값: INFO)")
 	flag.Parse()
 
@@ -363,6 +374,14 @@ func main() {
 	if err != nil {
 		slog.Error(err.Error())
 		os.Exit(1)
+	}
+
+	if *backfill {
+		if err := p.backfillSectors(ctx); err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+		return
 	}
 
 	if err := p.run(ctx); err != nil {

--- a/internal/writer/backfill.go
+++ b/internal/writer/backfill.go
@@ -1,0 +1,83 @@
+package writer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// padStockCode 는 숫자로만 된 6자리 미만 종목코드를 앞 0 패딩해 6자리로 복원한다.
+// (시트에 숫자로 저장돼 앞 0 이 유실된 코드 — 예 "55550"→"055550" — 를 KIS 조회용으로 복원.)
+// 영문 포함/이미 6자리/빈값은 그대로 둔다.
+func padStockCode(code string) string {
+	if code == "" || len(code) >= 6 {
+		return code
+	}
+	for _, r := range code {
+		if r < '0' || r > '9' {
+			return code
+		}
+	}
+	return strings.Repeat("0", 6-len(code)) + code
+}
+
+// backfillValues 는 종목코드 슬라이스를 (섹터,산업) 2D 값으로 변환한다(E:F 열 일괄 기록용).
+func backfillValues(codes []string, resolve func(code string) (sector, industry string)) [][]interface{} {
+	out := make([][]interface{}, len(codes))
+	for i, code := range codes {
+		s, ind := resolve(code)
+		out[i] = []interface{}{s, ind}
+	}
+	return out
+}
+
+// firstColStrings 는 한 열 조회 결과([][]interface{})의 각 행 첫 셀을 문자열로 추출한다(빈 행은 "").
+func firstColStrings(vals [][]interface{}) []string {
+	out := make([]string, len(vals))
+	for i, row := range vals {
+		if len(row) > 0 && row[0] != nil {
+			out[i] = fmt.Sprintf("%v", row[0])
+		}
+	}
+	return out
+}
+
+// BackfillSectors 는 국내 매매일지 시트의 기존 행에 섹터(E)/산업(F) 을 일괄 채운다.
+// 종목코드(C) 로 resolve 한 결과를 시트당 한 번의 batch 로 기록한다.
+// 신 포맷 국내 시트만 대상(해외는 설계상 공란, 구포맷/비매매일지는 스킵).
+func (w *Writer) BackfillSectors(ctx context.Context, resolve func(code string) (sector, industry string)) error {
+	names, err := w.getSheets(ctx)
+	if err != nil {
+		return err
+	}
+	for _, sheetName := range names {
+		headerVals, err := w.client.GetValues(ctx, sheetName+"!A1:Q1")
+		if err != nil {
+			slog.Error("헤더 조회 실패, 스킵", "sheet", sheetName, "err", err)
+			continue
+		}
+		if !headersEqual(extractHeaderRow(headerVals), DomesticHeaders) {
+			continue // 국내 신 포맷만
+		}
+		codeVals, err := w.client.GetValues(ctx, sheetName+"!C2:C")
+		if err != nil {
+			slog.Error("종목코드 조회 실패, 스킵", "sheet", sheetName, "err", err)
+			continue
+		}
+		codes := firstColStrings(codeVals)
+		if len(codes) == 0 {
+			continue
+		}
+		for i := range codes {
+			codes[i] = padStockCode(codes[i]) // 앞 0 유실 코드 복원
+		}
+		values := backfillValues(codes, resolve)
+		rng := fmt.Sprintf("%s!E2:F%d", sheetName, len(codes)+1)
+		if err := w.client.BatchUpdateValues(ctx, map[string][][]interface{}{rng: values}); err != nil {
+			return fmt.Errorf("섹터 백필(%s): %w", sheetName, err)
+		}
+		slog.Info("섹터/산업 백필 완료", "sheet", sheetName, "rows", len(codes))
+	}
+	return nil
+}

--- a/internal/writer/backfill_test.go
+++ b/internal/writer/backfill_test.go
@@ -1,0 +1,45 @@
+package writer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackfillValues(t *testing.T) {
+	resolve := func(code string) (string, string) {
+		switch code {
+		case "214150":
+			return "의료·정밀기기", "의료용 기기 제조업"
+		case "487240":
+			return "ETF", ""
+		default:
+			return "", ""
+		}
+	}
+	got := backfillValues([]string{"214150", "", "487240"}, resolve)
+	want := [][]interface{}{
+		{"의료·정밀기기", "의료용 기기 제조업"},
+		{"", ""},
+		{"ETF", ""},
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestPadStockCode(t *testing.T) {
+	assert.Equal(t, "055550", padStockCode("55550"))  // 앞 0 유실 복원
+	assert.Equal(t, "005935", padStockCode("5935"))   // 삼성전자우
+	assert.Equal(t, "005930", padStockCode("005930")) // 이미 6자리 → 그대로
+	assert.Equal(t, "0088N0", padStockCode("0088N0")) // 영문 포함 6자리 → 그대로
+	assert.Equal(t, "", padStockCode(""))             // 빈값 → 그대로
+	assert.Equal(t, "487240", padStockCode("487240")) // 6자리 숫자 → 그대로
+}
+
+func TestFirstColStrings(t *testing.T) {
+	vals := [][]interface{}{
+		{"005930"},
+		{}, // 빈 행
+		{"487240"},
+	}
+	assert.Equal(t, []string{"005930", "", "487240"}, firstColStrings(vals))
+}


### PR DESCRIPTION
## 배경
섹터/산업 보강(`enrichSectors`)은 **신규 삽입 거래에만** 적용되어, 이미 시트에 있던 기존 행(수천 건)은 섹터/산업 칸이 빈 채 남았다. `make run` 을 다시 돌려도 중복으로 걸러져 갱신되지 않는다.

## 변경 — 1회용 백필 모드
`--backfill-sectors` (= `make backfill-sectors`) 추가:
- `Writer.BackfillSectors`: 국내 신포맷 시트마다 종목코드(C)로 bizcat resolve → 섹터(E)/산업(F) 열을 **시트당 1 batch** 로 일괄 기록.
- `backfillValues` / `firstColStrings` 순수 헬퍼 + TDD.
- `padStockCode`: 시트에 숫자로 저장돼 **앞 0 이 유실된 코드**("55550"→"055550", "5935"→"005935")를 6자리로 복원. 안 하면 `KIER2620`(조회할 자료 없음)으로 실패.
- bizcat 의 페이싱(4/s) + 영구 캐시 + negative-cache 그대로 활용.

## 실측
- 국내 7개 시트 **~4,500행 12초**에 채움, **에러 0**.
- ETF → 섹터 "ETF" / 산업 공란. 일반 종목 → HPSP 섹터="기계·장비" 산업="특수 목적용 기계 제조업", 롯데리츠 섹터="리츠" 산업="부동산 임대 및 공급업".

## Test plan
- [x] `TestBackfillValues` / `TestFirstColStrings` / `TestPadStockCode`
- [x] `go build/vet/test ./...` 전체 통과
- [x] 실제 시트 백필 + 셀 값 확인