### PR TITLE
feat(bizcat): ETF 산업 열에 대표 업종명 채우기 (InquireEtfPrice)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ internal/
 2. **파서 감지**: CSV 헤더를 읽어 파서 자동 선택
 3. **파싱**: 증권사 형식에 맞춰 Trade 객체 리스트 생성
 4. **종목코드 보강**: 국내 거래 중 종목코드가 빈 항목을 KRX 마스터에서 조회해 채움
-4b. **섹터/산업 보강**: 국내 거래에 KIS 조회로 채움 — 섹터=InquirePrice 업종 한글명(bstp_kor_isnm), 산업=표준산업분류 (`internal/bizcat`, 해외는 공란)
+4b. **섹터/산업 보강**: 국내 거래에 KIS 조회로 채움 — 섹터=InquirePrice 업종 한글명(bstp_kor_isnm), 산업=표준산업분류. ETF 는 섹터="ETF", 산업=InquireEtfPrice 대표 업종명 (`internal/bizcat`, 해외는 공란)
 5. **시트 확인**: 시트가 없으면 자동 생성 + 헤더 삽입
 6. **중복 필터**: 기존 시트 데이터와 비교하여 중복 제거
 7. **데이터 삽입**: 신규 거래 일괄 삽입 + 숫자/통화 포맷 적용 (거래 시트 날짜별 배경색은 현재 미적용)
@@ -70,9 +70,10 @@ internal/
 - `Trade` struct (Sector/Industry 포함) + `ToDomesticRow`(12컬럼)/`ToForeignRow`(17컬럼)/`ToSheetRow` + `DuplicateKey`(DupKey; 섹터/산업 미포함)
 
 **internal/bizcat** (`resolver.go`):
-- 섹터 = `Domestic.InquirePrice(code)` 의 **업종 한글명**(`BstpKorIsnm`/bstp_kor_isnm, 예 "전기·전자"/"IT 서비스"/"의료·정밀기기"). 일반 종목 커버리지가 가장 넓고(지수업종 중분류는 대형주만 채워짐) moneyflow `sector_detail` 과 동일 소스. ETF 는 "ETF(실물복제/수익증권)" 라벨.
-- 산업 = `Domestic.SearchStockInfo(code,"300")` 의 **표준산업분류**(`StdIdstClsfCdName`, 예 "의료용 기기 제조업"). 일반 종목은 채워지고 ETF 는 공란. ⚠️ 지수업종(대/중/소분류)은 커버리지가 낮아 미사용.
-- 즉 코드당 InquirePrice + SearchStockInfo **2회 호출**. KIS 초당 제한(EGW00201) 회피를 위해 `WithRateLimit(kisCallsPerSec=4)` 로 호출을 페이싱하고, 같은 실행 내 실패 코드는 negative-cache(`failed`, 비영구)로 재조회를 막는다. 성공 결과는 `config/bizcat_cache.json` 에 영구 캐시(실행 간 유지).
+- 섹터 = `Domestic.InquirePrice(code)` 의 **업종 한글명**(`BstpKorIsnm`/bstp_kor_isnm, 예 "전기·전자"/"IT 서비스"/"의료·정밀기기"). 일반 종목 커버리지가 가장 넓고(지수업종 중분류는 대형주만 채워짐) moneyflow `sector_detail` 과 동일 소스. ETF 는 섹터를 짧게 `"ETF"` 로 정규화.
+- 산업 = `Domestic.SearchStockInfo(code,"300")` 의 **표준산업분류**(`StdIdstClsfCdName`, 예 "의료용 기기 제조업"). ⚠️ 지수업종(대/중/소분류)은 커버리지가 낮아 미사용.
+- **ETF 산업** = `Domestic.InquireEtfPrice(code)` 의 **대표 업종명**(`EtfRprsBstpKorIsnm`/etf_rprs_bstp_kor_isnm, 예 "반도체"). 표준산업분류가 비는 ETF 의 산업 열에 추종 섹터를 채운다. ETF 판별은 `EtfDvsnCd != ""`(+ bstp_kor_isnm "ETF…" 접두사 백업).
+- 즉 코드당 InquirePrice + SearchStockInfo **2회 호출**(ETF 는 InquireEtfPrice 까지 **3회**). KIS 초당 제한(EGW00201) 회피를 위해 `WithRateLimit(kisCallsPerSec=4)` 로 호출을 페이싱하고, 같은 실행 내 실패 코드는 negative-cache(`failed`, 비영구)로 재조회를 막는다. 성공 결과는 `config/bizcat_cache.json` 에 영구 캐시(실행 간 유지). 구버전 캐시의 `{섹터:"ETF", 산업:""}` 항목은 자가치유로 재조회되어 산업이 채워진다(`needsRefresh`).
 - 영구 캐시 `config/bizcat_cache.json`, lazy `kis.NewClientFromEnv()`. KIS 키 없거나 실패 시 빈 값(회복력).
 - atj 는 `ensureKISFileToken`(main.go)으로 **파일 토큰 강제** — env가 redis 라도 Redis 의존 없이 동작.
 

--- a/docs/superpowers/specs/2026-06-14-etf-industry-bizcat-design.md
+++ b/docs/superpowers/specs/2026-06-14-etf-industry-bizcat-design.md
@@ -1,0 +1,71 @@
+# ETF 산업 열에 대표 업종명 채우기 (bizcat)
+
+- 작성일: 2026-06-14
+- 범위: `internal/bizcat` (국내 매매일지 per-row 섹터/산업 보강)
+
+## 배경
+
+매매일지의 국내 거래 행에는 `섹터(E)` / `산업(F)` 열이 있고, `internal/bizcat` 패키지가
+종목코드로 KIS를 조회해 채운다(현재 흐름: `InquirePrice` + `SearchStockInfo`).
+
+- 일반 종목: `섹터 = bstp_kor_isnm`(업종 한글명), `산업 = std_idst_clsf_cd_name`(표준산업분류).
+- ETF: `섹터 = "ETF"`(긴 라벨을 #71에서 짧게 정규화), `산업 = ""`(표준산업분류가 비어 옴).
+
+문제: ETF 행은 섹터가 일률적으로 "ETF"이고 산업이 비어, 어떤 섹터를 추종하는 ETF인지
+매매일지에서 알 수 없다.
+
+## 목표
+
+ETF로 판별된 종목에 한해, 비어 있는 **산업 열**에 ETF가 추종하는 대표 업종명을 채운다.
+섹터 열의 "ETF" 라벨은 그대로 유지한다(ETF 식별자 보존, 정보 손실 없음).
+
+- 예: KODEX 반도체 → `섹터 = "ETF"`, `산업 = "반도체"`
+
+## 데이터 소스
+
+KIS SDK `domestic.InquireEtfPrice`(ETF/ETN 현재가, FHPST02400000)의
+`Output.EtfRprsBstpKorIsnm`(ETF 대표 업종 한글명).
+
+## 설계
+
+### 1. ETF 판별
+
+`SearchStockInfo` 응답의 `EtfDvsnCd != ""` 로 판별한다(일반 종목은 빈 값).
+기존 `bstp_kor_isnm` 접두사 휴리스틱보다 견고하다.
+
+### 2. 조회 흐름 (`kisFetch` 클로저)
+
+- 공통: `InquirePrice` + `SearchStockInfo` 호출(기존과 동일).
+- ETF인 경우에만 3번째 호출 `InquireEtfPrice{Symbol: code}` 추가:
+  - `섹터 = "ETF"` (유지)
+  - `산업 = Output.EtfRprsBstpKorIsnm` (신규)
+- 일반 종목: 호출 수·동작 변화 없음.
+- `InquireEtfPrice` 실패 시: 산업만 빈 값으로 두고 섹터="ETF"는 채운다(전체 실패로 만들지 않음).
+
+### 3. 캐시 자가 치유
+
+기존 `config/bizcat_cache.json`에 ETF가 `{sector:"ETF", industry:""}`로 이미 캐시돼 있어,
+그대로면 새 로직이 적용되지 않는다.
+
+`Resolve`에서 캐시 히트라도 `Sector == "ETF" && Industry == ""`이면 미스로 간주해 재조회한다.
+한 번 채워지면 이후 캐시를 사용한다. (별도 마이그레이션/캐시 버전 불필요)
+
+엣지: 대표 업종명이 실제로 빈 ETF는 매 실행 재조회된다(산업이 계속 ""). 개인 매매일지의
+ETF 코드 수가 적어(보통 한 자릿수) 비용이 무시할 만하므로 허용한다.
+
+### 4. 부수 사항
+
+- `kisCallsPerSec` 주석: "코드당 2회(ETF 3회)"로 갱신. 값 4는 유지.
+- `--backfill-sectors`(#73)는 동일 `Resolve`를 사용하므로 ETF 산업까지 자동 백필된다(코드 변경 없음).
+
+## 테스트
+
+- `extractSectorIndustry` 및 fetch 분기를 ETF / 일반 두 케이스로 단위 테스트(fetch는 주입형 stub).
+- 캐시 자가 치유: `{sector:"ETF", industry:""}` 캐시 항목이 재조회를 트리거하는지 검증.
+- 기존 `bizcat` 테스트가 그대로 통과하는지 확인(`go test ./...`).
+
+## 범위 밖 (YAGNI)
+
+- ETF 구성종목 가중집계로 섹터 추론.
+- 해외 ETF.
+- 섹터 열 결합 표기("ETF·반도체").

--- a/internal/bizcat/resolver.go
+++ b/internal/bizcat/resolver.go
@@ -52,11 +52,13 @@ func (r *Resolver) Resolve(code string) (string, string) {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if e, ok := r.cache[code]; ok {
-		return e.Sector, e.Industry
+	cached, hasCached := r.cache[code]
+	if hasCached && !needsRefresh(cached) {
+		return cached.Sector, cached.Industry
 	}
 	if r.failed[code] {
-		return "", "" // 이번 실행에서 이미 실패 → 재조회 안 함
+		// 이번 실행에서 이미 실패 → 재조회 안 함. 자가치유 대상이면 기존 캐시 보존.
+		return cached.Sector, cached.Industry
 	}
 	if r.fetch == nil {
 		r.fetch = kisFetch()
@@ -68,11 +70,18 @@ func (r *Resolver) Resolve(code string) (string, string) {
 		}
 		r.failed[code] = true
 		slog.Warn("업종 조회 실패, 빈 값 처리", "code", code, "err", err)
-		return "", ""
+		return cached.Sector, cached.Industry // 자가치유 재조회 실패 시 기존 캐시 보존
 	}
 	r.cache[code] = entry{Sector: sector, Industry: industry}
 	r.dirty = true
 	return sector, industry
+}
+
+// needsRefresh 는 캐시 히트라도 재조회가 필요한지 판단한다.
+// 구버전 캐시는 ETF 를 {섹터:"ETF", 산업:""} 로 저장했는데, 이제 산업 열에
+// ETF 대표 업종명을 채우므로 미스로 간주해 재조회한다(별도 마이그레이션 불필요).
+func needsRefresh(e entry) bool {
+	return e.Sector == "ETF" && e.Industry == ""
 }
 
 func (r *Resolver) Save() {
@@ -101,8 +110,8 @@ func (r *Resolver) saveCache() error {
 }
 
 // kisCallsPerSec 는 bizcat 업종 조회의 KIS 호출 빈도 상한.
-// 코드당 2회 호출(InquirePrice + SearchStockInfo)이라 SDK 기본(15/s)에선 초당 제한
-// (EGW00201)에 걸린다. 보수적으로 낮춰 한 실행에 빠짐없이 채워지도록 한다.
+// 코드당 2회 호출(InquirePrice + SearchStockInfo, ETF 는 InquireEtfPrice 까지 3회)이라
+// SDK 기본(15/s)에선 초당 제한(EGW00201)에 걸린다. 보수적으로 낮춰 한 실행에 빠짐없이 채워지도록 한다.
 const kisCallsPerSec = 4
 
 func kisFetch() func(string) (string, string, error) {
@@ -121,23 +130,38 @@ func kisFetch() func(string) (string, string, error) {
 		if err != nil {
 			return "", "", err
 		}
-		sector, industry := extractSectorIndustry(price, info)
+		// ETF 는 표준산업분류가 비므로, 대표 업종명(etf_rprs_bstp_kor_isnm)을 추가 조회해 산업 열에 채운다.
+		var etfIndustry string
+		if isETF(price, info) {
+			if etf, err := client.Domestic.InquireEtfPrice(ctx, domestic.InquireEtfPriceParams{Symbol: code}); err != nil {
+				slog.Warn("ETF 대표 업종 조회 실패, 산업 빈 값 처리", "code", code, "err", err)
+			} else {
+				etfIndustry = etf.Output.EtfRprsBstpKorIsnm
+			}
+		}
+		sector, industry := extractSectorIndustry(price, info, etfIndustry)
 		return sector, industry, nil
 	}
 }
 
+// isETF 는 종목이 ETF 인지 판별한다. SearchStockInfo 의 ETF 구분 코드(etf_dvsn_cd)를 1차
+// 신호로 쓰되, 비어 오는 경우를 대비해 업종 한글명 "ETF…" 접두사도 함께 본다.
+func isETF(price *domestic.Price, info *domestic.StockInfo) bool {
+	return info.EtfDvsnCd != "" || strings.HasPrefix(price.BstpKorIsnm, "ETF")
+}
+
 // extractSectorIndustry 는 KIS 응답에서 섹터/산업을 추출한다.
 //
+//   - 일반 종목
 //   - 섹터  = InquirePrice 의 업종 한글명(bstp_kor_isnm, 예 "전기·전자"/"IT 서비스"/"의료·정밀기기").
 //     지수업종 중분류가 비는 일반 종목(클래시스·솔루엠 등)도 채워져 커버리지가 가장 넓다.
-//     ETF 는 "ETF(실물복제/수익증권)" 라벨이 들어온다. moneyflow 의 sector_detail 과 동일 소스.
+//     moneyflow 의 sector_detail 과 동일 소스.
 //   - 산업  = search-stock-info 의 표준산업분류(std_idst_clsf_cd_name, 예 "의료용 기기 제조업").
-//     일반 종목은 채워지고 ETF 는 빈값.
-func extractSectorIndustry(price *domestic.Price, info *domestic.StockInfo) (sector, industry string) {
-	sector = price.BstpKorIsnm
-	// ETF 는 "ETF(실물복제/수익증권)" 등 긴 라벨로 오므로 짧게 "ETF" 로 정규화.
-	if strings.HasPrefix(sector, "ETF") {
-		sector = "ETF"
+//   - ETF: 섹터 = "ETF"(고정), 산업 = etfIndustry(InquireEtfPrice 의 대표 업종명, 예 "반도체").
+//     표준산업분류가 비는 ETF 의 산업 열을 추종 섹터로 채운다.
+func extractSectorIndustry(price *domestic.Price, info *domestic.StockInfo, etfIndustry string) (sector, industry string) {
+	if isETF(price, info) {
+		return "ETF", etfIndustry
 	}
-	return sector, info.StdIdstClsfCdName
+	return price.BstpKorIsnm, info.StdIdstClsfCdName
 }

--- a/internal/bizcat/resolver_test.go
+++ b/internal/bizcat/resolver_test.go
@@ -62,11 +62,13 @@ func TestResolve_EmptyCodeOrErrorReturnsBlank(t *testing.T) {
 
 // 섹터 = InquirePrice 업종 한글명(bstp_kor_isnm), 산업 = 표준산업분류(std_idst_clsf_cd_name).
 // bstp_kor_isnm 은 지수업종이 비는 일반 종목(클래시스 등)도 채워져 커버리지가 넓다.
+// ETF 는 섹터="ETF", 산업 = ETF 대표 업종명(InquireEtfPrice 의 etf_rprs_bstp_kor_isnm).
 func TestExtractSectorIndustry(t *testing.T) {
 	// 대형주: 둘 다 채워짐
 	s, i := extractSectorIndustry(
 		&domestic.Price{BstpKorIsnm: "전기·전자"},
 		&domestic.StockInfo{StdIdstClsfCdName: "반도체 제조업"},
+		"",
 	)
 	assert.Equal(t, "전기·전자", s)
 	assert.Equal(t, "반도체 제조업", i)
@@ -75,15 +77,50 @@ func TestExtractSectorIndustry(t *testing.T) {
 	s, i = extractSectorIndustry(
 		&domestic.Price{BstpKorIsnm: "의료·정밀기기"},
 		&domestic.StockInfo{StdIdstClsfCdName: "의료용 기기 제조업"},
+		"",
 	)
 	assert.Equal(t, "의료·정밀기기", s)
 	assert.Equal(t, "의료용 기기 제조업", i)
 
-	// ETF: bstp_kor_isnm "ETF(실물복제/수익증권)" → 섹터는 짧게 "ETF" 로 정규화, 산업 빈값
+	// ETF(EtfDvsnCd 로 판별): 섹터="ETF", 산업=대표 업종명
+	s, i = extractSectorIndustry(
+		&domestic.Price{BstpKorIsnm: "ETF(실물복제/수익증권)"},
+		&domestic.StockInfo{EtfDvsnCd: "1"},
+		"반도체",
+	)
+	assert.Equal(t, "ETF", s)
+	assert.Equal(t, "반도체", i)
+
+	// ETF 백워드 호환: EtfDvsnCd 가 비어도 bstp_kor_isnm "ETF…" 접두사로 판별
 	s, i = extractSectorIndustry(
 		&domestic.Price{BstpKorIsnm: "ETF(실물복제/수익증권)"},
 		&domestic.StockInfo{},
+		"2차전지",
 	)
+	assert.Equal(t, "ETF", s)
+	assert.Equal(t, "2차전지", i)
+}
+
+// 구버전 캐시(섹터="ETF", 산업="")는 미스로 간주해 재조회하여 산업을 채운다.
+func TestResolve_StaleETFRefetchesForIndustry(t *testing.T) {
+	calls := 0
+	r := &Resolver{
+		cache: map[string]entry{"069500": {Sector: "ETF", Industry: ""}},
+		fetch: func(code string) (string, string, error) { calls++; return "ETF", "반도체", nil },
+	}
+	s, i := r.Resolve("069500")
+	assert.Equal(t, "ETF", s)
+	assert.Equal(t, "반도체", i)
+	assert.Equal(t, 1, calls, "구버전 ETF 캐시는 재조회되어야 함")
+}
+
+// 자가치유 재조회가 실패하면 기존 ETF 섹터 캐시는 보존한다(섹터 공백화 방지).
+func TestResolve_StaleETFRefetchFailureKeepsCachedSector(t *testing.T) {
+	r := &Resolver{
+		cache: map[string]entry{"069500": {Sector: "ETF", Industry: ""}},
+		fetch: func(string) (string, string, error) { return "", "", assert.AnError },
+	}
+	s, i := r.Resolve("069500")
 	assert.Equal(t, "ETF", s)
 	assert.Equal(t, "", i)
 }


### PR DESCRIPTION
## Summary
국내 ETF 행의 비어 있던 **산업 열**에 ETF가 추종하는 대표 업종명을 채운다. 섹터="ETF" 라벨은 유지.

- 예: KODEX 반도체 → `섹터="ETF"`, `산업="반도체"`

기존엔 ETF의 산업이 표준산업분류(`std_idst_clsf_cd_name`) 공란이라 비어 있었다.

## Changes (`internal/bizcat/resolver.go`)
- `isETF`: `EtfDvsnCd != ""`(+ `bstp_kor_isnm` "ETF…" 접두사 백업)로 ETF 판별
- `kisFetch`: ETF 만 `InquireEtfPrice` 3번째 호출 추가 → `etf_rprs_bstp_kor_isnm`을 산업 열에. 일반 종목은 호출 수·동작 불변. ETF 조회 실패 시 산업만 공란(전체 실패 아님)
- `extractSectorIndustry`: ETF → `("ETF", etfIndustry)`, 일반 → 기존 로직
- 캐시 자가치유(`needsRefresh`): 구버전 `{섹터:"ETF", 산업:""}` 항목은 미스로 간주해 재조회, 재조회 실패 시 기존 ETF 섹터 캐시 보존(섹터 공백화 방지)
- `--backfill-sectors`(#73)는 동일 `Resolve` 사용으로 ETF 산업까지 자동 백필
- `CLAUDE.md` 및 설계 문서(`docs/superpowers/specs/`) 갱신

## Test plan
- [x] `go build ./...` / `go vet` / `gofmt` 클린
- [x] `go test ./...` 통과 (신규: ETF 산업 추출, 캐시 자가치유, 재조회 실패 시 섹터 보존)
- [ ] `make backfill-sectors` 또는 `make run` 으로 실데이터 확인 (ETF 산업 열에 대표 업종명 채워지는지)