### PR TITLE
feat(bizcat): ETF 산업 하이브리드 분류 (업종코드 + OpenAI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ internal/
 **internal/bizcat** (`resolver.go`):
 - 섹터 = `Domestic.InquirePrice(code)` 의 **업종 한글명**(`BstpKorIsnm`/bstp_kor_isnm, 예 "전기·전자"/"IT 서비스"/"의료·정밀기기"). 일반 종목 커버리지가 가장 넓고(지수업종 중분류는 대형주만 채워짐) moneyflow `sector_detail` 과 동일 소스. ETF 는 섹터를 짧게 `"ETF"` 로 정규화.
 - 산업 = `Domestic.SearchStockInfo(code,"300")` 의 **표준산업분류**(`StdIdstClsfCdName`, 예 "의료용 기기 제조업"). ⚠️ 지수업종(대/중/소분류)은 커버리지가 낮아 미사용.
-- **ETF 산업** = `Domestic.InquireEtfPrice(code)` 의 **대표 업종명**(`EtfRprsBstpKorIsnm`/etf_rprs_bstp_kor_isnm, 예 "반도체"). 표준산업분류가 비는 ETF 의 산업 열에 추종 섹터를 채운다. ETF 판별은 `EtfDvsnCd != ""`(+ bstp_kor_isnm "ETF…" 접두사 백업).
+- **ETF 산업**(하이브리드) = `Domestic.InquireEtfPrice(code)` 의 목표지수 업종코드(`EtfTrgtNmixBstpCode`)로 분기. 코드≠9999(국내 시장/섹터) → KRX 분류명(`EtfRprsBstpKorIsnm`, "KRX " 접두사 제거, 예 "반도체"/"종합"). 코드=9999(해외·테마, 보유 ETF의 ~80%) → **펀드 종목명 OpenAI 분류**(`internal/bizcat/etfclass.go`, 고정 taxonomy 19종: 미국주식/중국주식/…/반도체/2차전지/방위·우주항공/원자재/채권/기타테마). 분류기 미설정/실패 시 지수명 폴백. ETF 판별은 `EtfDvsnCd != ""`(+ bstp_kor_isnm "ETF…" 접두사 백업).
 - 즉 코드당 InquirePrice + SearchStockInfo **2회 호출**(ETF 는 InquireEtfPrice 까지 **3회**). KIS 초당 제한(EGW00201) 회피를 위해 `WithRateLimit(kisCallsPerSec=4)` 로 호출을 페이싱하고, 같은 실행 내 실패 코드는 negative-cache(`failed`, 비영구)로 재조회를 막는다. 성공 결과는 `config/bizcat_cache.json` 에 영구 캐시(실행 간 유지). 구버전 캐시의 `{섹터:"ETF", 산업:""}` 항목은 자가치유로 재조회되어 산업이 채워진다(`needsRefresh`).
 - 영구 캐시 `config/bizcat_cache.json`, lazy `kis.NewClientFromEnv()`. KIS 키 없거나 실패 시 빈 값(회복력).
 - atj 는 `ensureKISFileToken`(main.go)으로 **파일 토큰 강제** — env가 redis 라도 Redis 의존 없이 동작.

--- a/cmd/atj/main.go
+++ b/cmd/atj/main.go
@@ -55,9 +55,10 @@ func enrichDomesticCodes(trades []model.Trade, r resolver) {
 	}
 }
 
-// bizcatResolver 는 종목코드 → (섹터, 산업) 조회를 추상화한다(테스트 스텁 주입용).
+// bizcatResolver 는 종목코드/종목명 → (섹터, 산업) 조회를 추상화한다(테스트 스텁 주입용).
+// 종목명은 9999 미분류 ETF 의 OpenAI 분류 입력으로 쓰인다.
 type bizcatResolver interface {
-	Resolve(code string) (sector, industry string)
+	Resolve(code, name string) (sector, industry string)
 }
 
 // enrichSectors 는 국내 거래(코드 있음)에 섹터/산업을 채운다(in-place). 해외/무코드는 스킵.
@@ -65,7 +66,7 @@ func enrichSectors(trades []model.Trade, r bizcatResolver) {
 	for i := range trades {
 		t := &trades[i]
 		if t.IsDomestic() && t.StockCode != "" {
-			t.Sector, t.Industry = r.Resolve(t.StockCode)
+			t.Sector, t.Industry = r.Resolve(t.StockCode, t.StockName)
 		}
 	}
 }
@@ -129,12 +130,12 @@ func scanCSVFiles(root string) ([]csvFile, error) {
 
 // processor 는 주식 데이터 처리기. (Python StockDataProcessor)
 type processor struct {
-	dryRun     bool
-	client     *sheets.Client
-	writer     *writer.Writer
-	summary    *summary.Generator
-	symbolRes  resolver
-	bizcatRes  bizcatResolver
+	dryRun      bool
+	client      *sheets.Client
+	writer      *writer.Writer
+	summary     *summary.Generator
+	symbolRes   resolver
+	bizcatRes   bizcatResolver
 	bizcatStore *bizcat.Resolver
 }
 
@@ -166,6 +167,8 @@ func newProcessor(ctx context.Context, dryRun bool, cfg *config.Config) (*proces
 	}
 
 	bc := bizcat.New("config/bizcat_cache.json")
+	// 9999 미분류 ETF(해외·테마)는 종목명 기반 OpenAI 분류. 키 없으면 no-op(지수명 폴백).
+	bc.EnableETFClassifier(cfg.OpenAIAPIKey(), cfg.OpenAI.Model)
 
 	return &processor{
 		dryRun:      dryRun,

--- a/cmd/atj/main_test.go
+++ b/cmd/atj/main_test.go
@@ -87,7 +87,7 @@ func TestScanCSVFiles_MissingDir(t *testing.T) {
 
 type stubBizcat map[string][2]string
 
-func (s stubBizcat) Resolve(code string) (string, string) {
+func (s stubBizcat) Resolve(code, name string) (string, string) {
 	v, ok := s[code]
 	if !ok {
 		return "", ""

--- a/docs/superpowers/specs/2026-06-14-etf-industry-bizcat-design.md
+++ b/docs/superpowers/specs/2026-06-14-etf-industry-bizcat-design.md
@@ -1,71 +1,75 @@
-# ETF 산업 열에 대표 업종명 채우기 (bizcat)
+# ETF 산업 열 분류 채우기 (bizcat 하이브리드)
 
 - 작성일: 2026-06-14
-- 범위: `internal/bizcat` (국내 매매일지 per-row 섹터/산업 보강)
+- 범위: `internal/bizcat`, `internal/writer/backfill.go`, `cmd/atj/main.go`
 
 ## 배경
 
-매매일지의 국내 거래 행에는 `섹터(E)` / `산업(F)` 열이 있고, `internal/bizcat` 패키지가
-종목코드로 KIS를 조회해 채운다(현재 흐름: `InquirePrice` + `SearchStockInfo`).
+매매일지 국내 거래 행의 `섹터(E)` / `산업(F)` 열을 `internal/bizcat` 이 KIS 조회로 채운다.
+일반 종목은 섹터=업종 한글명(`bstp_kor_isnm`), 산업=표준산업분류(`std_idst_clsf_cd_name`).
+ETF 는 섹터="ETF", 산업은 비어 있었다.
 
-- 일반 종목: `섹터 = bstp_kor_isnm`(업종 한글명), `산업 = std_idst_clsf_cd_name`(표준산업분류).
-- ETF: `섹터 = "ETF"`(긴 라벨을 #71에서 짧게 정규화), `산업 = ""`(표준산업분류가 비어 옴).
+1차 시도(merged)로 ETF 산업에 `InquireEtfPrice.EtfRprsBstpKorIsnm`(대표 지수명)을 넣었으나,
+이는 "반도체/종합" 같은 분류가 아니라 **추종 지수의 풀네임**("S&P 500", "Bloomberg World ...")이라
+산업 분류로는 부적절했다.
 
-문제: ETF 행은 섹터가 일률적으로 "ETF"이고 산업이 비어, 어떤 섹터를 추종하는 ETF인지
-매매일지에서 알 수 없다.
+## 실측 (보유 ETF 85개)
+
+`EtfTrgtNmixBstpCode`(목표 지수 업종코드) 분포:
+- **분류됨 17개(20%)**: 국내 시장/섹터 ETF. 코드→KRX 업종명(0001 종합, 4003 반도체, 4005 은행 …).
+- **9999 미분류 68개(80%)**: 해외(S&P500·나스닥·니케이 …) + 국내 테마(2차전지·방위산업·AI …).
+  KIS 가 한국 업종으로 분류하지 않음.
+
+→ 업종코드 단독은 20%만 커버. 나머지 80%는 종목명 기반 분류가 필요.
 
 ## 목표
 
-ETF로 판별된 종목에 한해, 비어 있는 **산업 열**에 ETF가 추종하는 대표 업종명을 채운다.
-섹터 열의 "ETF" 라벨은 그대로 유지한다(ETF 식별자 보존, 정보 손실 없음).
+ETF 산업 열을 의미 있는 카테고리로 채운다. 섹터="ETF" 는 유지.
 
-- 예: KODEX 반도체 → `섹터 = "ETF"`, `산업 = "반도체"`
+- 코드 분류 ETF: KRX 업종명(예 "반도체", "은행", "종합")
+- 9999 ETF: 펀드 종목명 기반 OpenAI 분류(예 "미국주식", "방위·우주항공", "원자재")
 
-## 데이터 소스
+## 설계 (하이브리드)
 
-KIS SDK `domestic.InquireEtfPrice`(ETF/ETN 현재가, FHPST02400000)의
-`Output.EtfRprsBstpKorIsnm`(ETF 대표 업종 한글명).
+### 데이터 소스
+`domestic.InquireEtfPrice` 의 `EtfTrgtNmixBstpCode` + `EtfRprsBstpKorIsnm`.
 
-## 설계
+### ETF 산업 결정 (`resolveETFIndustry`, 순수 함수)
+- `trgtCode != "9999"` → `stripKRXPrefix(rprsName)` (KRX 분류명, "KRX " 접두사 제거)
+- `trgtCode == "9999"` → `classify(fundName)` (OpenAI ETF 분류기)
+  - 분류기 미설정/실패 시 `stripKRXPrefix(rprsName)` 로 폴백(지수명, 회복력)
 
-### 1. ETF 판별
+### ETF 전용 OpenAI 분류기 (`internal/bizcat/etfclass.go`, 신설)
+기존 `internal/sector` 는 GICS 12섹터라 ETF(시장/자산군/테마)에 부적합 → 별도 분류기.
 
-`SearchStockInfo` 응답의 `EtfDvsnCd != ""` 로 판별한다(일반 종목은 빈 값).
-기존 `bstp_kor_isnm` 접두사 휴리스틱보다 견고하다.
+고정 taxonomy(19종):
+```
+미국주식, 중국주식, 일본주식, 인도주식, 베트남주식, 글로벌주식,
+반도체, 2차전지, 바이오·헬스케어, AI·로봇, 신재생에너지, 원자력,
+방위·우주항공, 배당, 리츠·부동산, 원자재, 채권, 통화·단기금리, 기타테마
+```
+- 입력: 펀드 종목명(예 "KODEX 미국S&P500"). 지수명보다 지역·테마가 명확.
+- 단건 호출 + bizcat 영구 캐시(코드당 1회 분류 후 캐시). `STOCK_DATA_OPENAI_API_KEY` 없으면 분류기 nil.
+- 검증: 응답이 taxonomy 밖이면 "기타테마".
 
-### 2. 조회 흐름 (`kisFetch` 클로저)
+### 종목명 배선
+`Resolve(code)` → `Resolve(code, name string)`. ETF 9999 분류 입력으로 펀드명 전달.
+- `enrichSectors`: `r.Resolve(t.StockCode, t.StockName)`
+- `BackfillSectors`: 시트에서 C(코드)+D(종목명) 함께 읽어 전달
 
-- 공통: `InquirePrice` + `SearchStockInfo` 호출(기존과 동일).
-- ETF인 경우에만 3번째 호출 `InquireEtfPrice{Symbol: code}` 추가:
-  - `섹터 = "ETF"` (유지)
-  - `산업 = Output.EtfRprsBstpKorIsnm` (신규)
-- 일반 종목: 호출 수·동작 변화 없음.
-- `InquireEtfPrice` 실패 시: 산업만 빈 값으로 두고 섹터="ETF"는 채운다(전체 실패로 만들지 않음).
-
-### 3. 캐시 자가 치유
-
-기존 `config/bizcat_cache.json`에 ETF가 `{sector:"ETF", industry:""}`로 이미 캐시돼 있어,
-그대로면 새 로직이 적용되지 않는다.
-
-`Resolve`에서 캐시 히트라도 `Sector == "ETF" && Industry == ""`이면 미스로 간주해 재조회한다.
-한 번 채워지면 이후 캐시를 사용한다. (별도 마이그레이션/캐시 버전 불필요)
-
-엣지: 대표 업종명이 실제로 빈 ETF는 매 실행 재조회된다(산업이 계속 ""). 개인 매매일지의
-ETF 코드 수가 적어(보통 한 자릿수) 비용이 무시할 만하므로 허용한다.
-
-### 4. 부수 사항
-
-- `kisCallsPerSec` 주석: "코드당 2회(ETF 3회)"로 갱신. 값 4는 유지.
-- `--backfill-sectors`(#73)는 동일 `Resolve`를 사용하므로 ETF 산업까지 자동 백필된다(코드 변경 없음).
+### 캐시 버전 (선별 갱신)
+`entry` 에 `Version int` 추가. `needsRefresh(e) = e.Sector=="ETF" && e.Version<etfCacheVersion`.
+- 기존 ETF 캐시(지수명 산업, version 0)는 1회 재조회되어 하이브리드 적용.
+- 비-ETF 주식 캐시는 그대로 보존(전체 삭제 불필요).
+- 재조회 실패 시 기존 캐시 보존(섹터 공백화 방지).
 
 ## 테스트
-
-- `extractSectorIndustry` 및 fetch 분기를 ETF / 일반 두 케이스로 단위 테스트(fetch는 주입형 stub).
-- 캐시 자가 치유: `{sector:"ETF", industry:""}` 캐시 항목이 재조회를 트리거하는지 검증.
-- 기존 `bizcat` 테스트가 그대로 통과하는지 확인(`go test ./...`).
+- `resolveETFIndustry`: 코드분류/9999+분류기/9999+분류기실패 폴백 3케이스.
+- `stripKRXPrefix`: "KRX 반도체"→"반도체", "종합"→"종합".
+- `needsRefresh`: 구버전 ETF(version 0) 재조회, 신버전/비-ETF 미재조회.
+- etfclass 검증: taxonomy 밖 응답→"기타테마"(순수 검증 함수).
+- backfill: 2-arg resolve 시그니처, 코드+종목명 전달.
+- `go test ./...` 전체 통과.
 
 ## 범위 밖 (YAGNI)
-
-- ETF 구성종목 가중집계로 섹터 추론.
-- 해외 ETF.
-- 섹터 열 결합 표기("ETF·반도체").
+- ETF 구성종목 가중집계. 해외 ETF 섹터(국내 시트 한정). 배치 OpenAI 호출(단건+캐시로 충분).

--- a/internal/bizcat/etfclass.go
+++ b/internal/bizcat/etfclass.go
@@ -1,0 +1,95 @@
+package bizcat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// etfCategories 는 9999 미분류 ETF(해외·테마)를 분류할 고정 taxonomy.
+// KIS 업종코드로 분류되지 않는 해외 지수/자산군/테마 ETF 를 종목명으로 분류한다.
+var etfCategories = []string{
+	"미국주식", "중국주식", "일본주식", "인도주식", "베트남주식", "글로벌주식",
+	"반도체", "2차전지", "바이오·헬스케어", "AI·로봇", "신재생에너지", "원자력",
+	"방위·우주항공", "배당", "리츠·부동산", "원자재", "채권", "통화·단기금리", "기타테마",
+}
+
+// etfFallbackCategory 는 taxonomy 밖 응답/분류 불가 시 사용.
+const etfFallbackCategory = "기타테마"
+
+var etfCategorySet = func() map[string]bool {
+	m := make(map[string]bool, len(etfCategories))
+	for _, c := range etfCategories {
+		m[c] = true
+	}
+	return m
+}()
+
+// validateETFCategory 는 분류 결과가 taxonomy 안에 있으면 그대로, 아니면 기타테마로 정규화한다.
+func validateETFCategory(s string) string {
+	s = strings.TrimSpace(s)
+	if etfCategorySet[s] {
+		return s
+	}
+	return etfFallbackCategory
+}
+
+const etfClassifyTimeout = 30 * time.Second
+
+var etfSystemPrompt = fmt.Sprintf(`당신은 한국 상장 ETF 분류 전문가입니다.
+ETF 종목명을 보고 아래 카테고리 중 정확히 하나로 분류하세요.
+
+사용 가능한 카테고리: %s
+
+분류 기준:
+- 해외 주식형은 투자 지역 우선(미국주식/중국주식/일본주식/인도주식/베트남주식/글로벌주식).
+- 특정 섹터·테마가 핵심이면 해당 테마(반도체/2차전지/바이오·헬스케어/AI·로봇/신재생에너지/원자력/방위·우주항공) 우선.
+- 채권/국채/단기자금/CD금리는 채권 또는 통화·단기금리.
+- 금·은·원유 등 상품은 원자재. 리츠·부동산·인프라는 리츠·부동산. 배당·커버드콜은 배당.
+- 애매하거나 위에 없으면 기타테마.
+
+반드시 JSON 으로만 응답: {"category": "<카테고리>"}`, strings.Join(etfCategories, ", "))
+
+// newETFClassifier 는 ETF 종목명 → 카테고리 분류 함수를 만든다. apiKey 가 비면 nil 을 반환한다
+// (호출부는 nil 이면 지수명 폴백을 사용). 결과는 bizcat 영구 캐시에 저장돼 코드당 1회만 호출된다.
+func newETFClassifier(apiKey, model string) func(name string) (string, error) {
+	if apiKey == "" {
+		return nil
+	}
+	if model == "" {
+		model = "gpt-4o-mini"
+	}
+	client := openai.NewClient(apiKey)
+	return func(name string) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), etfClassifyTimeout)
+		defer cancel()
+		resp, err := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+			Model: model,
+			Messages: []openai.ChatCompletionMessage{
+				{Role: openai.ChatMessageRoleSystem, Content: etfSystemPrompt},
+				{Role: openai.ChatMessageRoleUser, Content: "ETF 종목명: " + name},
+			},
+			Temperature: 0,
+			ResponseFormat: &openai.ChatCompletionResponseFormat{
+				Type: openai.ChatCompletionResponseFormatTypeJSONObject,
+			},
+		})
+		if err != nil || len(resp.Choices) == 0 {
+			slog.Warn("ETF OpenAI 분류 실패", "name", name, "err", err)
+			return "", fmt.Errorf("etf classify: %w", err)
+		}
+		var out struct {
+			Category string `json:"category"`
+		}
+		if err := json.Unmarshal([]byte(resp.Choices[0].Message.Content), &out); err != nil {
+			slog.Warn("ETF OpenAI 응답 파싱 실패", "name", name, "err", err)
+			return "", err
+		}
+		return validateETFCategory(out.Category), nil
+	}
+}

--- a/internal/bizcat/resolver.go
+++ b/internal/bizcat/resolver.go
@@ -17,15 +17,26 @@ import (
 type entry struct {
 	Sector   string `json:"sector"`
 	Industry string `json:"industry"`
+	Version  int    `json:"v,omitempty"` // 분류 스키마 버전(ETF 하이브리드 분류 도입). 0=구버전.
 }
 
+// etfCacheVersion 은 현재 ETF 산업 분류 스키마 버전. 이보다 낮은 ETF 캐시는 재조회한다.
+const etfCacheVersion = 2
+
 type Resolver struct {
-	mu        sync.Mutex
-	cache     map[string]entry
-	failed    map[string]bool // 이번 실행에서 실패한 코드(negative cache, 비영구)
-	cachePath string
-	fetch     func(code string) (sector, industry string, err error)
-	dirty     bool
+	mu          sync.Mutex
+	cache       map[string]entry
+	failed      map[string]bool // 이번 실행에서 실패한 코드(negative cache, 비영구)
+	cachePath   string
+	fetch       func(code, name string) (sector, industry string, err error)
+	classifyETF func(name string) (string, error) // 9999 미분류 ETF 의 종목명 분류기(optional, nil 가능)
+	dirty       bool
+}
+
+// EnableETFClassifier 는 9999 미분류 ETF 의 OpenAI 종목명 분류를 활성화한다.
+// apiKey 가 비면 분류기는 nil 로 남아 지수명 폴백을 사용한다.
+func (r *Resolver) EnableETFClassifier(apiKey, model string) {
+	r.classifyETF = newETFClassifier(apiKey, model)
 }
 
 func New(cachePath string) *Resolver {
@@ -46,7 +57,7 @@ func (r *Resolver) cacheLookup(code string) (string, bool) {
 	return e.Sector, ok
 }
 
-func (r *Resolver) Resolve(code string) (string, string) {
+func (r *Resolver) Resolve(code, name string) (string, string) {
 	if code == "" {
 		return "", ""
 	}
@@ -61,9 +72,9 @@ func (r *Resolver) Resolve(code string) (string, string) {
 		return cached.Sector, cached.Industry
 	}
 	if r.fetch == nil {
-		r.fetch = kisFetch()
+		r.fetch = kisFetch(r.classifyETF)
 	}
-	sector, industry, err := r.fetch(code)
+	sector, industry, err := r.fetch(code, name)
 	if err != nil {
 		if r.failed == nil {
 			r.failed = map[string]bool{}
@@ -72,16 +83,16 @@ func (r *Resolver) Resolve(code string) (string, string) {
 		slog.Warn("업종 조회 실패, 빈 값 처리", "code", code, "err", err)
 		return cached.Sector, cached.Industry // 자가치유 재조회 실패 시 기존 캐시 보존
 	}
-	r.cache[code] = entry{Sector: sector, Industry: industry}
+	r.cache[code] = entry{Sector: sector, Industry: industry, Version: etfCacheVersion}
 	r.dirty = true
 	return sector, industry
 }
 
 // needsRefresh 는 캐시 히트라도 재조회가 필요한지 판단한다.
-// 구버전 캐시는 ETF 를 {섹터:"ETF", 산업:""} 로 저장했는데, 이제 산업 열에
-// ETF 대표 업종명을 채우므로 미스로 간주해 재조회한다(별도 마이그레이션 불필요).
+// ETF 산업 분류 스키마가 바뀌면(구버전=지수명/빈값) 미스로 간주해 재조회한다.
+// 비-ETF 주식 캐시는 영향받지 않는다(전체 삭제 불필요).
 func needsRefresh(e entry) bool {
-	return e.Sector == "ETF" && e.Industry == ""
+	return e.Sector == "ETF" && e.Version < etfCacheVersion
 }
 
 func (r *Resolver) Save() {
@@ -114,13 +125,13 @@ func (r *Resolver) saveCache() error {
 // SDK 기본(15/s)에선 초당 제한(EGW00201)에 걸린다. 보수적으로 낮춰 한 실행에 빠짐없이 채워지도록 한다.
 const kisCallsPerSec = 4
 
-func kisFetch() func(string) (string, string, error) {
+func kisFetch(classifyETF func(name string) (string, error)) func(code, name string) (string, string, error) {
 	client, err := kis.NewClientFromEnv(kis.WithRateLimit(kisCallsPerSec))
 	if err != nil {
 		slog.Warn("KIS 클라이언트 생성 실패, 업종 보강 비활성화", "err", err)
-		return func(string) (string, string, error) { return "", "", nil }
+		return func(code, name string) (string, string, error) { return "", "", nil }
 	}
-	return func(code string) (string, string, error) {
+	return func(code, name string) (string, string, error) {
 		ctx := context.Background()
 		price, err := client.Domestic.InquirePrice(ctx, code)
 		if err != nil {
@@ -130,18 +141,42 @@ func kisFetch() func(string) (string, string, error) {
 		if err != nil {
 			return "", "", err
 		}
-		// ETF 는 표준산업분류가 비므로, 대표 업종명(etf_rprs_bstp_kor_isnm)을 추가 조회해 산업 열에 채운다.
+		// ETF 는 표준산업분류가 비므로, 목표 지수 업종코드/지수명을 추가 조회해 산업을 하이브리드 분류한다.
 		var etfIndustry string
 		if isETF(price, info) {
 			if etf, err := client.Domestic.InquireEtfPrice(ctx, domestic.InquireEtfPriceParams{Symbol: code}); err != nil {
-				slog.Warn("ETF 대표 업종 조회 실패, 산업 빈 값 처리", "code", code, "err", err)
+				slog.Warn("ETF 분류 조회 실패, 산업 빈 값 처리", "code", code, "err", err)
 			} else {
-				etfIndustry = etf.Output.EtfRprsBstpKorIsnm
+				etfIndustry = resolveETFIndustry(etf.Output.EtfTrgtNmixBstpCode, etf.Output.EtfRprsBstpKorIsnm, name, classifyETF)
 			}
 		}
 		sector, industry := extractSectorIndustry(price, info, etfIndustry)
 		return sector, industry, nil
 	}
+}
+
+// etfUnclassifiedCode 는 KIS 목표지수 업종코드 중 "미분류"(해외·테마 ETF)를 뜻한다.
+const etfUnclassifiedCode = "9999"
+
+// resolveETFIndustry 는 ETF 산업 분류를 하이브리드로 결정한다.
+//   - 목표지수 업종코드가 분류됨(≠9999) → KRX 분류명(stripKRXPrefix). 예 "KRX 반도체"→"반도체", "종합".
+//   - 9999(해외·테마) → 펀드 종목명을 OpenAI 분류기로 카테고리화(예 "미국주식"/"방위·우주항공"/"원자재").
+//   - 분류기 미설정/실패 → 지수명(stripKRXPrefix) 폴백(회복력).
+func resolveETFIndustry(trgtCode, rprsName, fundName string, classify func(name string) (string, error)) string {
+	if trgtCode != etfUnclassifiedCode {
+		return stripKRXPrefix(rprsName)
+	}
+	if classify != nil {
+		if cat, err := classify(fundName); err == nil && cat != "" {
+			return cat
+		}
+	}
+	return stripKRXPrefix(rprsName)
+}
+
+// stripKRXPrefix 는 KRX 업종명의 "KRX " 접두사를 제거한다. 예 "KRX 반도체"→"반도체", "종합"→"종합".
+func stripKRXPrefix(s string) string {
+	return strings.TrimSpace(strings.TrimPrefix(s, "KRX "))
 }
 
 // isETF 는 종목이 ETF 인지 판별한다. SearchStockInfo 의 ETF 구분 코드(etf_dvsn_cd)를 1차

--- a/internal/bizcat/resolver_test.go
+++ b/internal/bizcat/resolver_test.go
@@ -14,9 +14,9 @@ func TestResolve_CacheHitSkipsFetch(t *testing.T) {
 	calls := 0
 	r := &Resolver{
 		cache: map[string]entry{"005930": {Sector: "전기·전자", Industry: "반도체"}},
-		fetch: func(code string) (string, string, error) { calls++; return "", "", nil },
+		fetch: func(code, name string) (string, string, error) { calls++; return "", "", nil },
 	}
-	s, i := r.Resolve("005930")
+	s, i := r.Resolve("005930", "삼성전자")
 	assert.Equal(t, "전기·전자", s)
 	assert.Equal(t, "반도체", i)
 	assert.Equal(t, 0, calls)
@@ -26,12 +26,12 @@ func TestResolve_MissCallsFetchAndCaches(t *testing.T) {
 	calls := 0
 	r := &Resolver{
 		cache: map[string]entry{},
-		fetch: func(code string) (string, string, error) { calls++; return "금융", "은행", nil },
+		fetch: func(code, name string) (string, string, error) { calls++; return "금융", "은행", nil },
 	}
-	s, i := r.Resolve("105560")
+	s, i := r.Resolve("105560", "KB금융")
 	assert.Equal(t, "금융", s)
 	assert.Equal(t, "은행", i)
-	r.Resolve("105560")
+	r.Resolve("105560", "KB금융")
 	assert.Equal(t, 1, calls)
 }
 
@@ -39,30 +39,29 @@ func TestResolve_MissCallsFetchAndCaches(t *testing.T) {
 // (영구 캐시엔 저장 안 함 — 다음 실행에는 다시 시도해야 하므로.)
 func TestResolve_NegativeCacheSkipsRefetchOnError(t *testing.T) {
 	calls := 0
-	r := &Resolver{cache: map[string]entry{}, fetch: func(string) (string, string, error) {
+	r := &Resolver{cache: map[string]entry{}, fetch: func(code, name string) (string, string, error) {
 		calls++
 		return "", "", assert.AnError
 	}}
-	s, i := r.Resolve("999999") // 1회차: fetch 실패
+	s, i := r.Resolve("999999", "유령") // 1회차: fetch 실패
 	assert.Equal(t, "", s)
 	assert.Equal(t, "", i)
-	r.Resolve("999999") // 2회차: negative cache 로 재조회 안 함
+	r.Resolve("999999", "유령") // 2회차: negative cache 로 재조회 안 함
 	assert.Equal(t, 1, calls, "실패 코드는 같은 실행 내 1회만 호출")
 }
 
 func TestResolve_EmptyCodeOrErrorReturnsBlank(t *testing.T) {
-	r := &Resolver{cache: map[string]entry{}, fetch: func(string) (string, string, error) { return "", "", assert.AnError }}
-	s, i := r.Resolve("")
+	r := &Resolver{cache: map[string]entry{}, fetch: func(code, name string) (string, string, error) { return "", "", assert.AnError }}
+	s, i := r.Resolve("", "")
 	assert.Equal(t, "", s)
 	assert.Equal(t, "", i)
-	s, i = r.Resolve("000000")
+	s, i = r.Resolve("000000", "x")
 	assert.Equal(t, "", s)
 	assert.Equal(t, "", i)
 }
 
 // 섹터 = InquirePrice 업종 한글명(bstp_kor_isnm), 산업 = 표준산업분류(std_idst_clsf_cd_name).
-// bstp_kor_isnm 은 지수업종이 비는 일반 종목(클래시스 등)도 채워져 커버리지가 넓다.
-// ETF 는 섹터="ETF", 산업 = ETF 대표 업종명(InquireEtfPrice 의 etf_rprs_bstp_kor_isnm).
+// ETF 는 섹터="ETF", 산업 = 사전 결정된 etfIndustry(resolveETFIndustry 결과).
 func TestExtractSectorIndustry(t *testing.T) {
 	// 대형주: 둘 다 채워짐
 	s, i := extractSectorIndustry(
@@ -82,7 +81,7 @@ func TestExtractSectorIndustry(t *testing.T) {
 	assert.Equal(t, "의료·정밀기기", s)
 	assert.Equal(t, "의료용 기기 제조업", i)
 
-	// ETF(EtfDvsnCd 로 판별): 섹터="ETF", 산업=대표 업종명
+	// ETF: 섹터="ETF", 산업=사전 결정 분류
 	s, i = extractSectorIndustry(
 		&domestic.Price{BstpKorIsnm: "ETF(실물복제/수익증권)"},
 		&domestic.StockInfo{EtfDvsnCd: "1"},
@@ -90,39 +89,74 @@ func TestExtractSectorIndustry(t *testing.T) {
 	)
 	assert.Equal(t, "ETF", s)
 	assert.Equal(t, "반도체", i)
-
-	// ETF 백워드 호환: EtfDvsnCd 가 비어도 bstp_kor_isnm "ETF…" 접두사로 판별
-	s, i = extractSectorIndustry(
-		&domestic.Price{BstpKorIsnm: "ETF(실물복제/수익증권)"},
-		&domestic.StockInfo{},
-		"2차전지",
-	)
-	assert.Equal(t, "ETF", s)
-	assert.Equal(t, "2차전지", i)
 }
 
-// 구버전 캐시(섹터="ETF", 산업="")는 미스로 간주해 재조회하여 산업을 채운다.
-func TestResolve_StaleETFRefetchesForIndustry(t *testing.T) {
+// resolveETFIndustry: 코드 분류(≠9999)는 KRX 분류명, 9999 는 분류기 결과, 분류기 실패/미설정 시 지수명 폴백.
+func TestResolveETFIndustry(t *testing.T) {
+	// 코드 분류된 국내 섹터 ETF → KRX 접두사 제거된 분류명
+	got := resolveETFIndustry("4003", "KRX 반도체", "KODEX 반도체", nil)
+	assert.Equal(t, "반도체", got)
+
+	// 9999 + 분류기 → 분류기 결과
+	got = resolveETFIndustry("9999", "S&P 500", "KODEX 미국S&P500",
+		func(name string) (string, error) { return "미국주식", nil })
+	assert.Equal(t, "미국주식", got)
+
+	// 9999 + 분류기 실패 → 지수명 폴백
+	got = resolveETFIndustry("9999", "S&P 500", "KODEX 미국S&P500",
+		func(name string) (string, error) { return "", assert.AnError })
+	assert.Equal(t, "S&P 500", got)
+
+	// 9999 + 분류기 미설정(nil) → 지수명 폴백
+	got = resolveETFIndustry("9999", "Nikkei 225", "TIGER 일본니케이225", nil)
+	assert.Equal(t, "Nikkei 225", got)
+}
+
+func TestStripKRXPrefix(t *testing.T) {
+	assert.Equal(t, "반도체", stripKRXPrefix("KRX 반도체"))
+	assert.Equal(t, "금현물지수", stripKRXPrefix("KRX 금현물지수"))
+	assert.Equal(t, "종합", stripKRXPrefix("종합"))
+	assert.Equal(t, "", stripKRXPrefix(""))
+}
+
+func TestValidateETFCategory(t *testing.T) {
+	assert.Equal(t, "미국주식", validateETFCategory("미국주식"))
+	assert.Equal(t, "방위·우주항공", validateETFCategory("방위·우주항공"))
+	assert.Equal(t, etfFallbackCategory, validateETFCategory("아무말"))
+	assert.Equal(t, etfFallbackCategory, validateETFCategory(""))
+}
+
+// needsRefresh 는 구버전 ETF 캐시(version < etfCacheVersion)만 재조회 대상으로 본다.
+func TestNeedsRefresh(t *testing.T) {
+	assert.True(t, needsRefresh(entry{Sector: "ETF", Industry: "S&P 500", Version: 0}), "구버전 ETF 재조회")
+	assert.True(t, needsRefresh(entry{Sector: "ETF", Industry: ""}), "산업 빈 구버전 ETF 재조회")
+	assert.False(t, needsRefresh(entry{Sector: "ETF", Industry: "미국주식", Version: etfCacheVersion}), "신버전 ETF 유지")
+	assert.False(t, needsRefresh(entry{Sector: "전기·전자", Industry: "반도체"}), "비-ETF 는 재조회 안 함")
+}
+
+// 구버전 ETF 캐시(지수명 산업, version 0)는 재조회되어 새 분류로 갱신되고, 이후엔 캐시 사용.
+func TestResolve_StaleETFRefetchesThenCaches(t *testing.T) {
 	calls := 0
 	r := &Resolver{
-		cache: map[string]entry{"069500": {Sector: "ETF", Industry: ""}},
-		fetch: func(code string) (string, string, error) { calls++; return "ETF", "반도체", nil },
+		cache: map[string]entry{"379780": {Sector: "ETF", Industry: "S&P 500"}}, // version 0
+		fetch: func(code, name string) (string, string, error) { calls++; return "ETF", "미국주식", nil },
 	}
-	s, i := r.Resolve("069500")
+	s, i := r.Resolve("379780", "RISE 미국S&P500")
 	assert.Equal(t, "ETF", s)
-	assert.Equal(t, "반도체", i)
-	assert.Equal(t, 1, calls, "구버전 ETF 캐시는 재조회되어야 함")
+	assert.Equal(t, "미국주식", i)
+	r.Resolve("379780", "RISE 미국S&P500") // 갱신 후엔 캐시 히트
+	assert.Equal(t, 1, calls, "재조회는 1회만")
 }
 
-// 자가치유 재조회가 실패하면 기존 ETF 섹터 캐시는 보존한다(섹터 공백화 방지).
-func TestResolve_StaleETFRefetchFailureKeepsCachedSector(t *testing.T) {
+// 자가치유 재조회가 실패하면 기존 ETF 캐시(섹터+산업)는 보존한다.
+func TestResolve_StaleETFRefetchFailureKeepsCached(t *testing.T) {
 	r := &Resolver{
-		cache: map[string]entry{"069500": {Sector: "ETF", Industry: ""}},
-		fetch: func(string) (string, string, error) { return "", "", assert.AnError },
+		cache: map[string]entry{"379780": {Sector: "ETF", Industry: "S&P 500"}},
+		fetch: func(code, name string) (string, string, error) { return "", "", assert.AnError },
 	}
-	s, i := r.Resolve("069500")
+	s, i := r.Resolve("379780", "RISE 미국S&P500")
 	assert.Equal(t, "ETF", s)
-	assert.Equal(t, "", i)
+	assert.Equal(t, "S&P 500", i)
 }
 
 func TestCacheSaveLoad_Roundtrip_PreservesKorean(t *testing.T) {

--- a/internal/writer/backfill.go
+++ b/internal/writer/backfill.go
@@ -22,36 +22,42 @@ func padStockCode(code string) string {
 	return strings.Repeat("0", 6-len(code)) + code
 }
 
-// backfillValues 는 종목코드 슬라이스를 (섹터,산업) 2D 값으로 변환한다(E:F 열 일괄 기록용).
-func backfillValues(codes []string, resolve func(code string) (sector, industry string)) [][]interface{} {
+// backfillValues 는 종목코드/종목명 슬라이스를 (섹터,산업) 2D 값으로 변환한다(E:F 열 일괄 기록용).
+// 종목명은 9999 미분류 ETF 의 OpenAI 분류 입력으로 쓰인다.
+func backfillValues(codes, stockNames []string, resolve func(code, name string) (sector, industry string)) [][]interface{} {
 	out := make([][]interface{}, len(codes))
 	for i, code := range codes {
-		s, ind := resolve(code)
+		name := ""
+		if i < len(stockNames) {
+			name = stockNames[i]
+		}
+		s, ind := resolve(code, name)
 		out[i] = []interface{}{s, ind}
 	}
 	return out
 }
 
-// firstColStrings 는 한 열 조회 결과([][]interface{})의 각 행 첫 셀을 문자열로 추출한다(빈 행은 "").
-func firstColStrings(vals [][]interface{}) []string {
+// colStrings 는 조회 결과([][]interface{})의 각 행 idx 번째 셀을 문자열로 추출한다(없으면 "").
+func colStrings(vals [][]interface{}, idx int) []string {
 	out := make([]string, len(vals))
 	for i, row := range vals {
-		if len(row) > 0 && row[0] != nil {
-			out[i] = fmt.Sprintf("%v", row[0])
+		if len(row) > idx && row[idx] != nil {
+			out[i] = fmt.Sprintf("%v", row[idx])
 		}
 	}
 	return out
 }
 
 // BackfillSectors 는 국내 매매일지 시트의 기존 행에 섹터(E)/산업(F) 을 일괄 채운다.
-// 종목코드(C) 로 resolve 한 결과를 시트당 한 번의 batch 로 기록한다.
+// 종목코드(C)+종목명(D) 로 resolve 한 결과를 시트당 한 번의 batch 로 기록한다.
+// (종목명은 9999 미분류 ETF 의 OpenAI 분류 입력으로 쓰임.)
 // 신 포맷 국내 시트만 대상(해외는 설계상 공란, 구포맷/비매매일지는 스킵).
-func (w *Writer) BackfillSectors(ctx context.Context, resolve func(code string) (sector, industry string)) error {
-	names, err := w.getSheets(ctx)
+func (w *Writer) BackfillSectors(ctx context.Context, resolve func(code, name string) (sector, industry string)) error {
+	sheetNames, err := w.getSheets(ctx)
 	if err != nil {
 		return err
 	}
-	for _, sheetName := range names {
+	for _, sheetName := range sheetNames {
 		headerVals, err := w.client.GetValues(ctx, sheetName+"!A1:Q1")
 		if err != nil {
 			slog.Error("헤더 조회 실패, 스킵", "sheet", sheetName, "err", err)
@@ -60,19 +66,20 @@ func (w *Writer) BackfillSectors(ctx context.Context, resolve func(code string) 
 		if !headersEqual(extractHeaderRow(headerVals), DomesticHeaders) {
 			continue // 국내 신 포맷만
 		}
-		codeVals, err := w.client.GetValues(ctx, sheetName+"!C2:C")
+		rowVals, err := w.client.GetValues(ctx, sheetName+"!C2:D")
 		if err != nil {
-			slog.Error("종목코드 조회 실패, 스킵", "sheet", sheetName, "err", err)
+			slog.Error("종목코드/종목명 조회 실패, 스킵", "sheet", sheetName, "err", err)
 			continue
 		}
-		codes := firstColStrings(codeVals)
+		codes := colStrings(rowVals, 0)      // C: 종목코드
+		stockNames := colStrings(rowVals, 1) // D: 종목명
 		if len(codes) == 0 {
 			continue
 		}
 		for i := range codes {
 			codes[i] = padStockCode(codes[i]) // 앞 0 유실 코드 복원
 		}
-		values := backfillValues(codes, resolve)
+		values := backfillValues(codes, stockNames, resolve)
 		rng := fmt.Sprintf("%s!E2:F%d", sheetName, len(codes)+1)
 		if err := w.client.BatchUpdateValues(ctx, map[string][][]interface{}{rng: values}); err != nil {
 			return fmt.Errorf("섹터 백필(%s): %w", sheetName, err)

--- a/internal/writer/backfill_test.go
+++ b/internal/writer/backfill_test.go
@@ -7,21 +7,24 @@ import (
 )
 
 func TestBackfillValues(t *testing.T) {
-	resolve := func(code string) (string, string) {
+	resolve := func(code, name string) (string, string) {
 		switch code {
 		case "214150":
 			return "의료·정밀기기", "의료용 기기 제조업"
 		case "487240":
-			return "ETF", ""
+			return "ETF", "미국주식" // 종목명 기반 ETF 분류
 		default:
 			return "", ""
 		}
 	}
-	got := backfillValues([]string{"214150", "", "487240"}, resolve)
+	got := backfillValues(
+		[]string{"214150", "", "487240"},
+		[]string{"클래시스", "", "KODEX 미국AI전력핵심설비"},
+		resolve)
 	want := [][]interface{}{
 		{"의료·정밀기기", "의료용 기기 제조업"},
 		{"", ""},
-		{"ETF", ""},
+		{"ETF", "미국주식"},
 	}
 	assert.Equal(t, want, got)
 }
@@ -35,11 +38,12 @@ func TestPadStockCode(t *testing.T) {
 	assert.Equal(t, "487240", padStockCode("487240")) // 6자리 숫자 → 그대로
 }
 
-func TestFirstColStrings(t *testing.T) {
+func TestColStrings(t *testing.T) {
 	vals := [][]interface{}{
-		{"005930"},
+		{"005930", "삼성전자"},
 		{}, // 빈 행
-		{"487240"},
+		{"487240", "KODEX 미국AI전력핵심설비"},
 	}
-	assert.Equal(t, []string{"005930", "", "487240"}, firstColStrings(vals))
+	assert.Equal(t, []string{"005930", "", "487240"}, colStrings(vals, 0))         // 코드(C)
+	assert.Equal(t, []string{"삼성전자", "", "KODEX 미국AI전력핵심설비"}, colStrings(vals, 1)) // 종목명(D)
 }


### PR DESCRIPTION
## Summary
ETF 산업 열을 의미 있는 카테고리로 채운다(섹터="ETF" 유지).

직전 PR #74 는 ETF 산업에 추종 지수 풀네임(`EtfRprsBstpKorIsnm`)을 넣었으나
"반도체/종합" 같은 분류가 아니라 지수명("S&P 500", "Bloomberg World ...")이라 부적절.

**실측**: 보유 ETF 85개 중 `EtfTrgtNmixBstpCode==9999`(미분류) 가 80%(68개) — 해외(S&P500·나스닥 등) + 국내 테마(2차전지·방위산업 등). 코드 단독 분류는 20%만 커버.

## 하이브리드 분류
- **코드 ≠ 9999** (국내 시장/섹터) → KRX 분류명(`stripKRXPrefix`, "KRX 반도체"→"반도체", "종합")
- **코드 = 9999** (해외·테마) → **펀드 종목명 OpenAI 분류** (`internal/bizcat/etfclass.go`, 고정 taxonomy 19종: 미국주식/중국주식/…/반도체/2차전지/방위·우주항공/원자재/채권/기타테마)
- 분류기 미설정/실패 → 지수명 폴백(회복력)

## Changes
- `internal/bizcat/resolver.go` — `resolveETFIndustry`(하이브리드), `stripKRXPrefix`, 버전 기반 `needsRefresh`
- `internal/bizcat/etfclass.go` (신규) — ETF 전용 OpenAI 분류기 + taxonomy + 검증
- `Resolve(code)` → `Resolve(code, name)` — 종목명을 ETF 분류 입력으로 전달 (`enrichSectors`, `BackfillSectors`는 C2:D 읽기)
- `entry.Version` + `needsRefresh` 버전화 — 구버전 ETF 캐시만 1회 재조회, 비-ETF 주식 캐시 보존(전체 삭제 불필요)
- `newProcessor` — `STOCK_DATA_OPENAI_API_KEY` 있으면 `EnableETFClassifier`
- `CLAUDE.md` / 설계 문서 갱신

## Test plan
- [x] `go build ./...` / `go vet` / `gofmt` / `go test ./...` 통과 (신규 단위테스트 7종: resolveETFIndustry, stripKRXPrefix, validateETFCategory, needsRefresh 버전, 캐시 재조회/실패보존, backfill 2-arg)
- [x] 실 OpenAI spike 22종 분류 정확 (지역/섹터/테마 모두, 미보유 테마만 기타테마 폴백)
- [ ] `make backfill-sectors` 실행 — ETF 85개 재분류(9999 68개 OpenAI), 시트 산업 열 확인