### PR TITLE
feat(fmpcat): 해외(미국·일본) 종목 섹터/산업 채우기 (FMP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,8 @@ internal/
 ├── parser   - Parser 인터페이스 + registry(DetectParser) + mirae/hankook
 │             (readCSVRows 가 CP949/UTF-8 네이티브 디코딩)
 ├── symbol   - KRX .mst → 종목코드 (fwf + cp949, 7일 캐시)
-├── bizcat   - KIS 업종 조회 → 섹터/산업 (InquirePrice + SearchStockInfo, 영구 캐시) — 거래행 섹터/산업 열용
+├── bizcat   - KIS 업종 조회 → 국내 섹터/산업 (InquirePrice + SearchStockInfo, 영구 캐시) — 거래행 섹터/산업 열용
+├── fmpcat   - FMP 회사 프로필 → 해외 섹터/산업 (Company.Profile, 영구 캐시, 통화→거래소 접미사 US/JP) — 해외 거래행용
 ├── sector   - OpenAI 섹터 분류 (go-openai, JSON 캐시) — 요약 "섹터별 투자비중"용 (bizcat과 별개)
 ├── sheets   - Google Sheets v4 래퍼 (값/포맷/색상/필터/차트 + 레이트리밋 재시도)
 ├── writer   - 시트 생성/중복필터/삽입 + ReadAllTrades
@@ -50,7 +51,7 @@ internal/
 2. **파서 감지**: CSV 헤더를 읽어 파서 자동 선택
 3. **파싱**: 증권사 형식에 맞춰 Trade 객체 리스트 생성
 4. **종목코드 보강**: 국내 거래 중 종목코드가 빈 항목을 KRX 마스터에서 조회해 채움
-4b. **섹터/산업 보강**: 국내 거래에 KIS 조회로 채움 — 섹터=InquirePrice 업종 한글명(bstp_kor_isnm), 산업=표준산업분류. ETF 는 섹터="ETF", 산업=InquireEtfPrice 대표 업종명 (`internal/bizcat`, 해외는 공란)
+4b. **섹터/산업 보강**: 국내 거래는 KIS(`internal/bizcat`) — 섹터=InquirePrice 업종 한글명(bstp_kor_isnm), 산업=표준산업분류. ETF 는 섹터="ETF", 산업=종목명 OpenAI taxonomy. **해외 거래는 FMP(`internal/fmpcat`)** — 통화로 거래소 접미사(US/JP)를 붙여 `Company.Profile` 조회, 섹터/산업 영문 원본
 5. **시트 확인**: 시트가 없으면 자동 생성 + 헤더 삽입
 6. **중복 필터**: 기존 시트 데이터와 비교하여 중복 제거
 7. **데이터 삽입**: 신규 거래 일괄 삽입 + 숫자/통화 포맷 적용 (거래 시트 날짜별 배경색은 현재 미적용)
@@ -73,9 +74,15 @@ internal/
 - 섹터 = `Domestic.InquirePrice(code)` 의 **업종 한글명**(`BstpKorIsnm`/bstp_kor_isnm, 예 "전기·전자"/"IT 서비스"/"의료·정밀기기"). 일반 종목 커버리지가 가장 넓고(지수업종 중분류는 대형주만 채워짐) moneyflow `sector_detail` 과 동일 소스. ETF 는 섹터를 짧게 `"ETF"` 로 정규화.
 - 산업 = `Domestic.SearchStockInfo(code,"300")` 의 **표준산업분류**(`StdIdstClsfCdName`, 예 "의료용 기기 제조업"). ⚠️ 지수업종(대/중/소분류)은 커버리지가 낮아 미사용.
 - **ETF 산업** = **펀드 종목명을 OpenAI taxonomy 로 분류**(`internal/bizcat/etfclass.go`, 고정 25종: 한국/미국/중국/일본/인도/베트남/글로벌주식 · 반도체/2차전지/바이오·헬스케어/AI·로봇/신재생에너지/원자력/방위·우주항공/자동차/금융/건설/필수소비재/IT·인터넷 · 배당/리츠·부동산/원자재/채권/통화·단기금리 · 기타테마). 코드 분류 여부와 무관하게 종목명으로 통일(verbose 한 KRX 지수명도 정규화). 분류기 미설정/실패 시 `Domestic.InquireEtfPrice` 의 지수명(`EtfRprsBstpKorIsnm`, "KRX " 접두사 제거) 폴백. ETF 판별은 `EtfDvsnCd != ""`(+ bstp_kor_isnm "ETF…" 접두사 백업).
-- 즉 코드당 InquirePrice + SearchStockInfo **2회 호출**(ETF 는 InquireEtfPrice 까지 **3회**). KIS 초당 제한(EGW00201) 회피를 위해 `WithRateLimit(kisCallsPerSec=4)` 로 호출을 페이싱하고, 같은 실행 내 실패 코드는 negative-cache(`failed`, 비영구)로 재조회를 막는다. 성공 결과는 `config/bizcat_cache.json` 에 영구 캐시(실행 간 유지). 구버전 캐시의 `{섹터:"ETF", 산업:""}` 항목은 자가치유로 재조회되어 산업이 채워진다(`needsRefresh`).
+- 즉 코드당 InquirePrice + SearchStockInfo **2회 호출**(ETF 는 InquireEtfPrice 까지 **3회**). KIS 초당 제한(EGW00201) 회피를 위해 `WithRateLimit(kisCallsPerSec=3)` 로 호출을 페이싱하고, 같은 실행 내 실패 코드는 negative-cache(`failed`, 비영구)로 재조회를 막는다. 성공 결과는 `config/bizcat_cache.json` 에 영구 캐시(실행 간 유지). 구버전 캐시의 `{섹터:"ETF", 산업:""}` 항목은 자가치유로 재조회되어 산업이 채워진다(`needsRefresh`).
 - 영구 캐시 `config/bizcat_cache.json`, lazy `kis.NewClientFromEnv()`. KIS 키 없거나 실패 시 빈 값(회복력).
 - atj 는 `ensureKISFileToken`(main.go)으로 **파일 토큰 강제** — env가 redis 라도 Redis 의존 없이 동작.
+
+**internal/fmpcat** (`resolver.go`) — 해외 종목 섹터/산업:
+- `Resolve(ticker, currency)` → FMP `Company.Profile(symbol)` 의 **영문 섹터/산업**(예 AAPL→Technology/Consumer Electronics). 표기는 영문 원본(나라별 비중 분석용).
+- `exchangeSuffix(currency)`: 통화로 거래소 접미사. 현재 **US/JP 만**(`USD→""`, `JPY→".T"`), 그 외 통화는 미지원→공란. 캐시 키 = `ticker+suffix`(예 "7203.T").
+- not-found(`fmp.ErrNotFound`; 해외 ETF·미커버)는 빈 값으로 영구 캐시(재조회 안 함). 일시적 오류만 negative-cache 재시도.
+- 영구 캐시 `config/fmpcat_cache.json`, lazy `fmp.NewClientFromEnv()`(`FMP_API_KEY`). 키 없으면 no-op(공란).
 
 **internal/parser** (`parser.go`, `mirae.go`, `hankook.go`, `registry.go`):
 - `Parser` 인터페이스(Name/CanParse/Parse), `DetectParser`(헤더 기반 자동 선택, 순서 Mirae국내→Mirae해외→Hankook)
@@ -118,6 +125,8 @@ logging:
 **Environment Variables** (optional override):
 - `GOOGLE_SPREADSHEET_ID`: 스프레드시트 ID
 - `SERVICE_ACCOUNT_PATH`: 서비스 계정 키 파일 경로
+- `STOCK_DATA_OPENAI_API_KEY`: OpenAI 키(국내 ETF 산업 분류 + 대시보드 섹터 분류). 없으면 해당 기능 비활성
+- `FMP_API_KEY`: FMP 키(해외 종목 섹터/산업). 없으면 해외 보강 비활성(공란)
 
 ### Google Sheets Setup
 
@@ -138,9 +147,9 @@ logging:
 ### 시트 컬럼 구조 (섹터/산업 포함)
 
 국내계좌 시트는 **12컬럼**: 일자, 구분, 종목코드, 종목명, **섹터, 산업**, 수량, 단가, 금액,
-수수료, 손익금액, 수익률(%). 해외계좌 시트는 **17컬럼**(종목명 뒤 섹터/산업, 해외는 공란).
+수수료, 손익금액, 수익률(%). 해외계좌 시트는 **17컬럼**(종목명 뒤 섹터=F/산업=G, FMP 영문).
 - 종목코드: CSV에 없으면 KRX 마스터(`internal/symbol`)에서 조회.
-- 섹터/산업: 국내만 KIS 조회(`internal/bizcat`, 섹터=InquirePrice 업종 한글명 / 산업=표준산업분류)로 채움. 해외 공란.
+- 섹터/산업: 국내는 KIS(`internal/bizcat`, 섹터=업종 한글명 / 산업=표준산업분류), 해외는 FMP(`internal/fmpcat`, 영문 섹터/산업, 통화→거래소 접미사 US/JP). 미지원 통화·미커버(해외 ETF)는 공란.
 
 **기존 시트 마이그레이션**: 섹터/산업(또는 종목코드) 컬럼 도입 이전 포맷(10/15/9컬럼) 시트는
 헤더 불일치로 **경고 로그와 함께 스킵**됩니다(자동 변환 안 함). 시트를 삭제 후 재실행하거나

--- a/cmd/atj/main.go
+++ b/cmd/atj/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kenshin579/auto-trading-journal/internal/bizcat"
 	"github.com/kenshin579/auto-trading-journal/internal/config"
+	"github.com/kenshin579/auto-trading-journal/internal/fmpcat"
 	"github.com/kenshin579/auto-trading-journal/internal/model"
 	"github.com/kenshin579/auto-trading-journal/internal/parser"
 	"github.com/kenshin579/auto-trading-journal/internal/sector"
@@ -55,18 +56,30 @@ func enrichDomesticCodes(trades []model.Trade, r resolver) {
 	}
 }
 
-// bizcatResolver 는 종목코드/종목명 → (섹터, 산업) 조회를 추상화한다(테스트 스텁 주입용).
+// bizcatResolver 는 국내 종목코드/종목명 → (섹터, 산업) 조회를 추상화한다(테스트 스텁 주입용).
 // 종목명은 9999 미분류 ETF 의 OpenAI 분류 입력으로 쓰인다.
 type bizcatResolver interface {
 	Resolve(code, name string) (sector, industry string)
 }
 
-// enrichSectors 는 국내 거래(코드 있음)에 섹터/산업을 채운다(in-place). 해외/무코드는 스킵.
-func enrichSectors(trades []model.Trade, r bizcatResolver) {
+// foreignResolver 는 해외 티커/통화 → (섹터, 산업) 조회를 추상화한다(테스트 스텁 주입용).
+// 통화로 FMP 거래소 접미사를 정한다(US/JP).
+type foreignResolver interface {
+	Resolve(ticker, currency string) (sector, industry string)
+}
+
+// enrichSectors 는 거래(코드 있음)에 섹터/산업을 채운다(in-place). 국내는 KIS, 해외는 FMP.
+// 코드 없는 거래는 스킵.
+func enrichSectors(trades []model.Trade, dom bizcatResolver, fgn foreignResolver) {
 	for i := range trades {
 		t := &trades[i]
-		if t.IsDomestic() && t.StockCode != "" {
-			t.Sector, t.Industry = r.Resolve(t.StockCode, t.StockName)
+		if t.StockCode == "" {
+			continue
+		}
+		if t.IsDomestic() {
+			t.Sector, t.Industry = dom.Resolve(t.StockCode, t.StockName)
+		} else {
+			t.Sector, t.Industry = fgn.Resolve(t.StockCode, t.Currency)
 		}
 	}
 }
@@ -137,6 +150,8 @@ type processor struct {
 	symbolRes   resolver
 	bizcatRes   bizcatResolver
 	bizcatStore *bizcat.Resolver
+	fmpRes      foreignResolver
+	fmpStore    *fmpcat.Resolver
 }
 
 // newProcessor 는 config 를 로드하고 모든 의존성을 조립한다.
@@ -170,6 +185,9 @@ func newProcessor(ctx context.Context, dryRun bool, cfg *config.Config) (*proces
 	// 9999 미분류 ETF(해외·테마)는 종목명 기반 OpenAI 분류. 키 없으면 no-op(지수명 폴백).
 	bc.EnableETFClassifier(cfg.OpenAIAPIKey(), cfg.OpenAI.Model)
 
+	// 해외 종목 섹터/산업은 FMP 로 채운다(FMP_API_KEY 없으면 no-op).
+	fc := fmpcat.New("config/fmpcat_cache.json")
+
 	return &processor{
 		dryRun:      dryRun,
 		client:      client,
@@ -178,6 +196,8 @@ func newProcessor(ctx context.Context, dryRun bool, cfg *config.Config) (*proces
 		symbolRes:   symbol.New(),
 		bizcatRes:   bc,
 		bizcatStore: bc,
+		fmpRes:      fc,
+		fmpStore:    fc,
 	}, nil
 }
 
@@ -200,7 +220,7 @@ func (p *processor) processFile(ctx context.Context, f csvFile) ([]model.Trade, 
 		return nil, err
 	}
 	enrichDomesticCodes(trades, p.symbolRes)
-	enrichSectors(trades, p.bizcatRes)
+	enrichSectors(trades, p.bizcatRes, p.fmpRes)
 	if len(trades) == 0 {
 		slog.Warn(fmt.Sprintf("파싱 결과 없음: %s", filepath.Base(f.path)))
 		return nil, nil
@@ -256,14 +276,17 @@ func (p *processor) processFile(ctx context.Context, f csvFile) ([]model.Trade, 
 }
 
 // run 은 메인 실행: CSV 스캔 → 파일별 처리 → 대시보드 갱신. (Python run)
-// backfillSectors 는 기존 국내 시트 행의 섹터/산업 열을 일괄 채운다(1회용).
+// backfillSectors 는 기존 국내/해외 시트 행의 섹터/산업 열을 일괄 채운다(1회용).
 func (p *processor) backfillSectors(ctx context.Context) error {
 	slog.Info("=== 섹터/산업 백필 시작 (기존 행 갱신) ===")
 	defer slog.Info("스크립트 실행 완료")
 	if p.bizcatStore != nil {
 		defer p.bizcatStore.Save()
 	}
-	return p.writer.BackfillSectors(ctx, p.bizcatRes.Resolve)
+	if p.fmpStore != nil {
+		defer p.fmpStore.Save()
+	}
+	return p.writer.BackfillSectors(ctx, p.bizcatRes.Resolve, p.fmpRes.Resolve)
 }
 
 func (p *processor) run(ctx context.Context) error {
@@ -271,6 +294,9 @@ func (p *processor) run(ctx context.Context) error {
 	defer slog.Info("스크립트 실행 완료")
 	if p.bizcatStore != nil {
 		defer p.bizcatStore.Save()
+	}
+	if p.fmpStore != nil {
+		defer p.fmpStore.Save()
 	}
 
 	// 1. CSV 파일 스캔 및 시트 삽입

--- a/cmd/atj/main_test.go
+++ b/cmd/atj/main_test.go
@@ -95,15 +95,28 @@ func (s stubBizcat) Resolve(code, name string) (string, string) {
 	return v[0], v[1]
 }
 
-func TestEnrichSectors_DomesticOnly(t *testing.T) {
+type stubForeign map[string][2]string
+
+func (s stubForeign) Resolve(ticker, currency string) (string, string) {
+	v, ok := s[ticker]
+	if !ok {
+		return "", ""
+	}
+	return v[0], v[1]
+}
+
+func TestEnrichSectors_DomesticAndForeign(t *testing.T) {
 	trades := []model.Trade{
 		{StockCode: "005930", Account: "미래에셋증권_국내계좌"},
-		{StockCode: "AAPL", Account: "미래에셋증권_해외계좌"},
+		{StockCode: "AAPL", Currency: "USD", Account: "미래에셋증권_해외계좌"},
 		{StockCode: "", Account: "미래에셋증권_국내계좌"}, // 코드 없음 → 미보강
 	}
-	enrichSectors(trades, stubBizcat{"005930": {"전기·전자", "반도체"}})
-	assert.Equal(t, "전기·전자", trades[0].Sector)
+	enrichSectors(trades,
+		stubBizcat{"005930": {"전기·전자", "반도체"}},
+		stubForeign{"AAPL": {"Technology", "Consumer Electronics"}})
+	assert.Equal(t, "전기·전자", trades[0].Sector) // 국내 KIS
 	assert.Equal(t, "반도체", trades[0].Industry)
-	assert.Equal(t, "", trades[1].Sector) // 해외 미보강
+	assert.Equal(t, "Technology", trades[1].Sector) // 해외 FMP
+	assert.Equal(t, "Consumer Electronics", trades[1].Industry)
 	assert.Equal(t, "", trades[2].Sector) // 코드 없음
 }

--- a/docs/superpowers/specs/2026-06-14-foreign-sector-fmp-design.md
+++ b/docs/superpowers/specs/2026-06-14-foreign-sector-fmp-design.md
@@ -1,0 +1,69 @@
+# 해외(미국·일본) 종목 섹터/산업 채우기 (FMP)
+
+- 작성일: 2026-06-14
+- 범위: `internal/fmpcat`(신규), `cmd/atj/main.go`, `internal/writer/backfill.go`
+
+## 배경
+
+해외 시트(17컬럼)의 `섹터(F)`/`산업(G)` 열은 설계상 공란이다(`ToForeignRow` 빈 값,
+`enrichSectors` 는 `IsDomestic` 만 처리, `BackfillSectors` 는 국내 헤더만 대상).
+국내는 `internal/bizcat`(KIS)로 채워지지만 해외는 비어 있다.
+
+## 데이터 소스 결정: FMP (`fmp-go`)
+
+- KIS 해외 SDK: `InquirePriceDetail().EIcod`(업종 코드만) → 섹터/산업 분류 부적합.
+- **FMP `Company.Profile(symbol)`** → `Sector`/`Industry`(영문) 반환. 검증 완료:
+  - AAPL→Technology/Consumer Electronics, NVDA→Technology/Semiconductors,
+    7203.T→Consumer Cyclical/Auto-Manufacturers, 0700.HK→Communication Services/...
+- 비미국은 **거래소 접미사 필수**(`7203`→not found, `7203.T`→OK).
+- 해외 ETF(`1321.T` 등)는 FMP 미커버(not found).
+
+## 결정 사항
+
+- **표기**: 섹터·산업 모두 **FMP 영문 원본** 그대로(추후 대시보드 나라별 비중 분석용).
+- **범위(통화→거래소 접미사)**: 현재 **US/JP 만**. `USD→""`, `JPY→".T"`. 그 외 통화는 공란(추후 확장).
+- **not-found/해외 ETF**: 공란(추후 필요 시 확장).
+
+## 설계 (bizcat 대칭)
+
+### internal/fmpcat 리졸버
+```
+Resolve(ticker, currency string) (sector, industry string)
+```
+- `exchangeSuffix(currency)`: `USD→("",true)`, `JPY→(".T",true)`, 그 외 `("",false)`.
+  - 미지원 통화 → 즉시 공란 반환(FMP 호출 안 함).
+- `symbol = ticker + suffix`, **캐시 키 = symbol**.
+- `fetch(symbol)`: `FMP Company.Profile(symbol)` → `(Sector, Industry)`.
+  - `errors.Is(err, fmp.ErrNotFound)` → `("","",nil)` 반환 → **빈 값으로 영구 캐시**(재조회 안 함; 해외 ETF/미커버).
+  - 그 외 오류 → 에러 전파 → negative-cache(이번 실행만, 다음 실행 재시도).
+- 영구 캐시 `config/fmpcat_cache.json`(lazy, 한글 없음). `FMP_API_KEY` 없으면 클라이언트 생성 실패 → no-op fetch(회복력).
+- 비결정적 호출 아님(FMP 응답 안정) → 캐시 버전 불필요.
+
+### enrichSectors 해외 분기 (`cmd/atj/main.go`)
+```
+enrichSectors(trades, bizcatRes, fmpRes)
+  국내(IsDomestic, code≠"")  → bizcatRes.Resolve(code, name)
+  해외(IsForeign, code≠"")   → fmpRes.Resolve(ticker=code, currency)
+```
+- `foreignResolver` 인터페이스(`Resolve(ticker, currency) (string,string)`) 추가(스텁 주입).
+- processor 에 `fmpRes`/`fmpStore` 필드, `newProcessor` 에서 `fmpcat.New(...)` 조립 + `Save()` defer.
+
+### BackfillSectors 해외 시트 지원 (`internal/writer/backfill.go`)
+시트 헤더로 국내/해외 분기:
+- `DomesticHeaders` → C:D(코드,종목명) 읽기, `domesticResolve(code,name)`, **E:F** 기록(기존).
+- `ForeignHeaders` → C:D(통화,종목코드) 읽기, `foreignResolve(ticker=D, currency=C)`, **F:G** 기록.
+- 그 외(구포맷/비매매일지) 스킵.
+- 시그니처: `BackfillSectors(ctx, domesticResolve, foreignResolve)`.
+
+## 테스트
+- `exchangeSuffix`: USD→"", JPY→".T", 기타→미지원.
+- `Resolve`: 미지원 통화→공란(fetch 미호출), USD 캐시 히트/미스, JPY 접미사 부착, not-found→빈 캐시(재조회 안 함), 에러→negative-cache 재시도.
+- `backfillValues` 해외용(통화+티커 입력).
+- `BackfillSectors` 헤더 분기(국내 E:F / 해외 F:G) — 가능 범위 단위 테스트.
+- `enrichSectors` 해외 분기(스텁) + 기존 국내 유지.
+- `go test ./...` 전체 통과.
+
+## 범위 밖 (YAGNI)
+- US/JP 외 통화(HK/CN/EU/VN 등) — 보유 시 확장.
+- 해외 ETF 분류(OpenAI 재사용) — 추후.
+- 대시보드 나라별 섹터/산업 비중 — 별도 작업.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kenshin579/auto-trading-journal
 go 1.25.8
 
 require (
+	github.com/kenshin579/fmp-go v0.29.1
 	github.com/kenshin579/korea-investment-stock v1.28.0
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/googleapis/gax-go/v2 v2.22.0 h1:PjIWBpgGIVKGoCXuiCoP64altEJCj3/Ei+kSU
 github.com/googleapis/gax-go/v2 v2.22.0/go.mod h1:irWBbALSr0Sk3qlqb9SyJ1h68WjgeFuiOzI4Rqw5+aY=
 github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
 github.com/jarcoal/httpmock v1.4.1/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
+github.com/kenshin579/fmp-go v0.29.1 h1:jmWUjhma/4xumn9qIeL7pH4VT5ofxDoS82FucKjWE9Q=
+github.com/kenshin579/fmp-go v0.29.1/go.mod h1:8fiROWlf61P5dErutVlPKeygTMWw6x1ZbscEmgSL544=
 github.com/kenshin579/korea-investment-stock v1.28.0 h1:L8I4bM1iBOLWvTS4YptwrWtADPLXV439rlwJmGs9/00=
 github.com/kenshin579/korea-investment-stock v1.28.0/go.mod h1:ApfNXi+Pe6HQt6E0JpsfLpVgTwVJFofj3OpCeKO+qh0=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=

--- a/internal/fmpcat/resolver.go
+++ b/internal/fmpcat/resolver.go
@@ -1,0 +1,139 @@
+// Package fmpcat 는 FMP(Financial Modeling Prep) 회사 프로필로 해외 종목의
+// 섹터/산업(영문)을 티커로 조회한다. (국내 internal/bizcat 의 해외 대응판.)
+package fmpcat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+
+	fmp "github.com/kenshin579/fmp-go"
+)
+
+type entry struct {
+	Sector   string `json:"sector"`
+	Industry string `json:"industry"`
+}
+
+type Resolver struct {
+	mu        sync.Mutex
+	cache     map[string]entry
+	failed    map[string]bool // 이번 실행에서 실패한 심볼(negative cache, 비영구)
+	cachePath string
+	fetch     func(symbol string) (sector, industry string, err error)
+	dirty     bool
+}
+
+func New(cachePath string) *Resolver {
+	r := &Resolver{cache: map[string]entry{}, cachePath: cachePath}
+	if data, err := os.ReadFile(cachePath); err == nil {
+		var m map[string]entry
+		if json.Unmarshal(data, &m) == nil && m != nil {
+			r.cache = m
+		} else {
+			slog.Warn("fmpcat 캐시 로드 실패, 빈 캐시로 시작", "path", cachePath)
+		}
+	}
+	return r
+}
+
+func (r *Resolver) cacheLookup(symbol string) (string, bool) {
+	e, ok := r.cache[symbol]
+	return e.Sector, ok
+}
+
+// exchangeSuffix 는 통화로 FMP 거래소 접미사를 정한다. 현재 US/JP 만 지원
+// (그 외 통화는 미지원 → 공란). 보유 국가 추가 시 여기에 매핑을 늘린다.
+func exchangeSuffix(currency string) (string, bool) {
+	switch currency {
+	case "USD":
+		return "", true // 미국: 접미사 없음
+	case "JPY":
+		return ".T", true // 도쿄
+	default:
+		return "", false
+	}
+}
+
+// Resolve 는 해외 티커+통화로 (섹터, 산업)을 조회한다(영문). 미지원 통화/빈 티커는 공란.
+func (r *Resolver) Resolve(ticker, currency string) (string, string) {
+	if ticker == "" {
+		return "", ""
+	}
+	suffix, ok := exchangeSuffix(currency)
+	if !ok {
+		return "", "" // 미지원 통화 → 공란(FMP 호출 안 함)
+	}
+	symbol := ticker + suffix
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.cache[symbol]; ok {
+		return e.Sector, e.Industry
+	}
+	if r.failed[symbol] {
+		return "", "" // 이번 실행에서 이미 실패 → 재조회 안 함
+	}
+	if r.fetch == nil {
+		r.fetch = fmpFetch()
+	}
+	sector, industry, err := r.fetch(symbol)
+	if err != nil {
+		if r.failed == nil {
+			r.failed = map[string]bool{}
+		}
+		r.failed[symbol] = true
+		slog.Warn("FMP 프로필 조회 실패, 빈 값 처리", "symbol", symbol, "err", err)
+		return "", ""
+	}
+	// not-found 는 fetch 가 ("","",nil)로 반환 → 빈 값으로 영구 캐시(해외 ETF/미커버, 재조회 안 함).
+	r.cache[symbol] = entry{Sector: sector, Industry: industry}
+	r.dirty = true
+	return sector, industry
+}
+
+func (r *Resolver) Save() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.dirty {
+		return
+	}
+	if err := r.saveCache(); err != nil {
+		slog.Warn("fmpcat 캐시 저장 실패", "err", err)
+	} else {
+		r.dirty = false
+	}
+}
+
+func (r *Resolver) saveCache() error {
+	f, err := os.Create(r.cachePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r.cache)
+}
+
+func fmpFetch() func(string) (string, string, error) {
+	client, err := fmp.NewClientFromEnv()
+	if err != nil {
+		slog.Warn("FMP 클라이언트 생성 실패, 해외 섹터 보강 비활성화", "err", err)
+		return func(string) (string, string, error) { return "", "", nil }
+	}
+	return func(symbol string) (string, string, error) {
+		p, err := client.Company.Profile(context.Background(), symbol)
+		if err != nil {
+			if errors.Is(err, fmp.ErrNotFound) {
+				return "", "", nil // 미커버(해외 ETF 등) → 빈 값으로 캐시(재조회 안 함)
+			}
+			return "", "", err // 일시적 오류 → negative-cache, 다음 실행 재시도
+		}
+		return p.Sector, p.Industry, nil
+	}
+}

--- a/internal/fmpcat/resolver_test.go
+++ b/internal/fmpcat/resolver_test.go
@@ -1,0 +1,117 @@
+package fmpcat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExchangeSuffix(t *testing.T) {
+	s, ok := exchangeSuffix("USD")
+	assert.Equal(t, "", s)
+	assert.True(t, ok)
+
+	s, ok = exchangeSuffix("JPY")
+	assert.Equal(t, ".T", s)
+	assert.True(t, ok)
+
+	_, ok = exchangeSuffix("EUR")
+	assert.False(t, ok, "미지원 통화")
+	_, ok = exchangeSuffix("")
+	assert.False(t, ok)
+}
+
+// 미지원 통화는 FMP 호출 없이 공란 반환.
+func TestResolve_UnsupportedCurrencySkipsFetch(t *testing.T) {
+	calls := 0
+	r := &Resolver{cache: map[string]entry{}, fetch: func(symbol string) (string, string, error) {
+		calls++
+		return "X", "Y", nil
+	}}
+	s, i := r.Resolve("BABA", "HKD")
+	assert.Equal(t, "", s)
+	assert.Equal(t, "", i)
+	assert.Equal(t, 0, calls, "미지원 통화는 fetch 안 함")
+}
+
+func TestResolve_EmptyTickerReturnsBlank(t *testing.T) {
+	r := &Resolver{cache: map[string]entry{}}
+	s, i := r.Resolve("", "USD")
+	assert.Equal(t, "", s)
+	assert.Equal(t, "", i)
+}
+
+// USD 는 접미사 없이 티커 그대로 조회, 결과 캐시.
+func TestResolve_USMissCachesThenHit(t *testing.T) {
+	calls := 0
+	var gotSymbol string
+	r := &Resolver{cache: map[string]entry{}, fetch: func(symbol string) (string, string, error) {
+		calls++
+		gotSymbol = symbol
+		return "Technology", "Consumer Electronics", nil
+	}}
+	s, i := r.Resolve("AAPL", "USD")
+	assert.Equal(t, "Technology", s)
+	assert.Equal(t, "Consumer Electronics", i)
+	assert.Equal(t, "AAPL", gotSymbol, "USD 는 접미사 없음")
+	r.Resolve("AAPL", "USD")
+	assert.Equal(t, 1, calls, "캐시 히트")
+}
+
+// JPY 는 .T 접미사를 붙여 조회.
+func TestResolve_JPYAppendsSuffix(t *testing.T) {
+	var gotSymbol string
+	r := &Resolver{cache: map[string]entry{}, fetch: func(symbol string) (string, string, error) {
+		gotSymbol = symbol
+		return "Consumer Cyclical", "Auto - Manufacturers", nil
+	}}
+	s, i := r.Resolve("7203", "JPY")
+	assert.Equal(t, "7203.T", gotSymbol, "JPY 는 .T 접미사")
+	assert.Equal(t, "Consumer Cyclical", s)
+	assert.Equal(t, "Auto - Manufacturers", i)
+}
+
+// not-found(fetch 가 빈 값+nil 반환)는 빈 값으로 캐시되어 재조회하지 않는다(해외 ETF 등).
+func TestResolve_NotFoundCachedEmpty(t *testing.T) {
+	calls := 0
+	r := &Resolver{cache: map[string]entry{}, fetch: func(symbol string) (string, string, error) {
+		calls++
+		return "", "", nil
+	}}
+	s, i := r.Resolve("1321", "JPY")
+	assert.Equal(t, "", s)
+	assert.Equal(t, "", i)
+	r.Resolve("1321", "JPY")
+	assert.Equal(t, 1, calls, "빈 결과도 캐시되어 재조회 안 함")
+}
+
+// 일시적 오류는 negative-cache(이번 실행만) → 같은 실행 내 재조회 안 함.
+func TestResolve_ErrorNegativeCache(t *testing.T) {
+	calls := 0
+	r := &Resolver{cache: map[string]entry{}, fetch: func(symbol string) (string, string, error) {
+		calls++
+		return "", "", assert.AnError
+	}}
+	s, i := r.Resolve("AAPL", "USD")
+	assert.Equal(t, "", s)
+	assert.Equal(t, "", i)
+	r.Resolve("AAPL", "USD")
+	assert.Equal(t, 1, calls, "실패 심볼은 같은 실행 내 1회만")
+}
+
+func TestCacheSaveLoad_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fmpcat_cache.json")
+	r := &Resolver{cache: map[string]entry{"AAPL": {Sector: "Technology", Industry: "Consumer Electronics"}}, cachePath: path}
+	require.NoError(t, r.saveCache())
+	data, _ := os.ReadFile(path)
+	assert.Contains(t, string(data), "Consumer Electronics")
+
+	r2 := New(path)
+	s, ok := r2.cacheLookup("AAPL")
+	assert.True(t, ok)
+	assert.Equal(t, "Technology", s)
+}

--- a/internal/writer/backfill.go
+++ b/internal/writer/backfill.go
@@ -22,16 +22,16 @@ func padStockCode(code string) string {
 	return strings.Repeat("0", 6-len(code)) + code
 }
 
-// backfillValues 는 종목코드/종목명 슬라이스를 (섹터,산업) 2D 값으로 변환한다(E:F 열 일괄 기록용).
-// 종목명은 9999 미분류 ETF 의 OpenAI 분류 입력으로 쓰인다.
-func backfillValues(codes, stockNames []string, resolve func(code, name string) (sector, industry string)) [][]interface{} {
-	out := make([][]interface{}, len(codes))
-	for i, code := range codes {
-		name := ""
-		if i < len(stockNames) {
-			name = stockNames[i]
+// backfillValues 는 (키, 보조) 슬라이스를 (섹터,산업) 2D 값으로 변환한다(섹터/산업 2열 일괄 기록용).
+// 국내: 키=종목코드, 보조=종목명(9999 ETF OpenAI 입력). 해외: 키=티커, 보조=통화(거래소 접미사).
+func backfillValues(keys, aux []string, resolve func(key, aux string) (sector, industry string)) [][]interface{} {
+	out := make([][]interface{}, len(keys))
+	for i, key := range keys {
+		a := ""
+		if i < len(aux) {
+			a = aux[i]
 		}
-		s, ind := resolve(code, name)
+		s, ind := resolve(key, a)
 		out[i] = []interface{}{s, ind}
 	}
 	return out
@@ -48,11 +48,16 @@ func colStrings(vals [][]interface{}, idx int) []string {
 	return out
 }
 
-// BackfillSectors 는 국내 매매일지 시트의 기존 행에 섹터(E)/산업(F) 을 일괄 채운다.
-// 종목코드(C)+종목명(D) 로 resolve 한 결과를 시트당 한 번의 batch 로 기록한다.
-// (종목명은 9999 미분류 ETF 의 OpenAI 분류 입력으로 쓰임.)
-// 신 포맷 국내 시트만 대상(해외는 설계상 공란, 구포맷/비매매일지는 스킵).
-func (w *Writer) BackfillSectors(ctx context.Context, resolve func(code, name string) (sector, industry string)) error {
+// BackfillSectors 는 기존 매매일지 시트의 섹터/산업 열을 일괄 채운다(시트당 한 번의 batch).
+//   - 국내 시트: 종목코드(C)+종목명(D) → domesticResolve → E·F 열.
+//   - 해외 시트: 통화(C)+종목코드/티커(D) → foreignResolve(ticker, currency) → F·G 열.
+//
+// 구포맷/비매매일지 시트는 스킵.
+func (w *Writer) BackfillSectors(
+	ctx context.Context,
+	domesticResolve func(code, name string) (sector, industry string),
+	foreignResolve func(ticker, currency string) (sector, industry string),
+) error {
 	sheetNames, err := w.getSheets(ctx)
 	if err != nil {
 		return err
@@ -63,28 +68,41 @@ func (w *Writer) BackfillSectors(ctx context.Context, resolve func(code, name st
 			slog.Error("헤더 조회 실패, 스킵", "sheet", sheetName, "err", err)
 			continue
 		}
-		if !headersEqual(extractHeaderRow(headerVals), DomesticHeaders) {
-			continue // 국내 신 포맷만
-		}
+		header := extractHeaderRow(headerVals)
 		rowVals, err := w.client.GetValues(ctx, sheetName+"!C2:D")
 		if err != nil {
-			slog.Error("종목코드/종목명 조회 실패, 스킵", "sheet", sheetName, "err", err)
+			slog.Error("종목 행 조회 실패, 스킵", "sheet", sheetName, "err", err)
 			continue
 		}
-		codes := colStrings(rowVals, 0)      // C: 종목코드
-		stockNames := colStrings(rowVals, 1) // D: 종목명
-		if len(codes) == 0 {
+
+		var keys, aux []string // keys=resolve 첫 인자, aux=둘째 인자
+		var resolve func(key, aux string) (string, string)
+		var writeRange string
+		switch {
+		case headersEqual(header, DomesticHeaders):
+			keys = colStrings(rowVals, 0) // C: 종목코드
+			aux = colStrings(rowVals, 1)  // D: 종목명
+			for i := range keys {
+				keys[i] = padStockCode(keys[i]) // 앞 0 유실 코드 복원(국내만)
+			}
+			resolve = domesticResolve
+			writeRange = fmt.Sprintf("%s!E2:F%d", sheetName, len(keys)+1)
+		case headersEqual(header, ForeignHeaders):
+			aux = colStrings(rowVals, 0)  // C: 통화
+			keys = colStrings(rowVals, 1) // D: 종목코드(티커)
+			resolve = foreignResolve
+			writeRange = fmt.Sprintf("%s!F2:G%d", sheetName, len(keys)+1)
+		default:
+			continue // 구포맷/비매매일지 스킵
+		}
+		if len(keys) == 0 {
 			continue
 		}
-		for i := range codes {
-			codes[i] = padStockCode(codes[i]) // 앞 0 유실 코드 복원
-		}
-		values := backfillValues(codes, stockNames, resolve)
-		rng := fmt.Sprintf("%s!E2:F%d", sheetName, len(codes)+1)
-		if err := w.client.BatchUpdateValues(ctx, map[string][][]interface{}{rng: values}); err != nil {
+		values := backfillValues(keys, aux, resolve)
+		if err := w.client.BatchUpdateValues(ctx, map[string][][]interface{}{writeRange: values}); err != nil {
 			return fmt.Errorf("섹터 백필(%s): %w", sheetName, err)
 		}
-		slog.Info("섹터/산업 백필 완료", "sheet", sheetName, "rows", len(codes))
+		slog.Info("섹터/산업 백필 완료", "sheet", sheetName, "rows", len(keys))
 	}
 	return nil
 }

--- a/internal/writer/backfill_test.go
+++ b/internal/writer/backfill_test.go
@@ -29,6 +29,25 @@ func TestBackfillValues(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+// 해외용: 키=티커, 보조=통화 → FMP resolve.
+func TestBackfillValues_Foreign(t *testing.T) {
+	resolve := func(ticker, currency string) (string, string) {
+		if ticker == "AAPL" && currency == "USD" {
+			return "Technology", "Consumer Electronics"
+		}
+		return "", "" // 미커버/미지원 통화
+	}
+	got := backfillValues(
+		[]string{"AAPL", "1321"},
+		[]string{"USD", "JPY"},
+		resolve)
+	want := [][]interface{}{
+		{"Technology", "Consumer Electronics"},
+		{"", ""},
+	}
+	assert.Equal(t, want, got)
+}
+
 func TestPadStockCode(t *testing.T) {
 	assert.Equal(t, "055550", padStockCode("55550"))  // 앞 0 유실 복원
 	assert.Equal(t, "005935", padStockCode("5935"))   // 삼성전자우


### PR DESCRIPTION
## Summary
해외 시트의 섹터(F)/산업(G) 열이 설계상 공란이던 것을 **FMP 회사 프로필**로 채운다.
국내(KIS)와 대칭 구조.

## 데이터 소스
- KIS 해외 SDK는 업종 코드만(`EIcod`) → 부적합
- **FMP `Company.Profile`** → 영문 섹터/산업 (검증: AAPL→Technology/Consumer Electronics, 7203.T→Consumer Cyclical/Auto-Manufacturers)

## Changes
- **`internal/fmpcat`** (신규, bizcat 대칭): `Resolve(ticker, currency)` → FMP 영문 섹터/산업
  - `exchangeSuffix`: 통화→거래소 접미사. 현재 **US/JP**(`USD→""`, `JPY→".T"`), 그 외 미지원→공란. 캐시 키=`ticker+suffix`
  - `fmp.ErrNotFound`(해외 ETF·미커버) → 빈 값 영구 캐시(재조회 안 함), 일시적 오류만 재시도
  - `config/fmpcat_cache.json`, `FMP_API_KEY` 없으면 no-op
- `enrichSectors`: 해외 분기 추가(국내→KIS, 해외→FMP)
- `BackfillSectors`: 해외 시트 지원(통화 C·티커 D 읽고 **F:G** 기록; 국내는 E:F). 해외 티커는 padStockCode 미적용
- `fmp-go v0.29.1` 의존 추가, `CLAUDE.md` 갱신

## 표기 결정
- 섹터·산업 모두 **FMP 영문 원본**(추후 대시보드 나라별 비중 분석용)

## Test plan
- [x] `go build`/`vet`/`gofmt`/`go test ./...` 통과 (exchangeSuffix, Resolve 캐시/접미사/not-found/negative-cache, enrichSectors 해외 분기, backfillValues 해외)
- [x] 실 FMP spike: AAPL/BAC/NEE(US), 7203(JP) 정확 / 1321(닛케이ETF)·BABA(HKD 미지원)→공란
- [ ] 머지 후 `make backfill-sectors` 로 해외 시트 섹터/산업 채우기

## 범위 밖 (YAGNI)
- US/JP 외 통화(HK/CN/EU 등), 해외 ETF 분류 — 보유 시 확장