### PR TITLE
chore(fmpcat): 해외 종목 섹터/산업 FMP 캐시 커밋

### DIFF
--- a/config/fmpcat_cache.json
+++ b/config/fmpcat_cache.json
@@ -1,0 +1,418 @@
+{
+  "1321.T": {
+    "sector": "",
+    "industry": ""
+  },
+  "1489.T": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Income"
+  },
+  "AAPL": {
+    "sector": "Technology",
+    "industry": "Consumer Electronics"
+  },
+  "ADC": {
+    "sector": "Real Estate",
+    "industry": "REIT - Retail"
+  },
+  "AIG": {
+    "sector": "Financial Services",
+    "industry": "Insurance - Diversified"
+  },
+  "ALLY": {
+    "sector": "Financial Services",
+    "industry": "Financial - Credit Services"
+  },
+  "AMD": {
+    "sector": "Technology",
+    "industry": "Semiconductors"
+  },
+  "AMT": {
+    "sector": "Real Estate",
+    "industry": "REIT - Specialty"
+  },
+  "AMZN": {
+    "sector": "Consumer Cyclical",
+    "industry": "Specialty Retail"
+  },
+  "ANET": {
+    "sector": "Technology",
+    "industry": "Computer Hardware"
+  },
+  "APLE": {
+    "sector": "Real Estate",
+    "industry": "REIT - Hotel & Motel"
+  },
+  "APP": {
+    "sector": "Technology",
+    "industry": "Software - Application"
+  },
+  "ARKK": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "ARKX": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "AVGO": {
+    "sector": "Technology",
+    "industry": "Semiconductors"
+  },
+  "AXP": {
+    "sector": "Financial Services",
+    "industry": "Financial - Credit Services"
+  },
+  "B": {
+    "sector": "Basic Materials",
+    "industry": "Gold"
+  },
+  "BAC": {
+    "sector": "Financial Services",
+    "industry": "Banks - Diversified"
+  },
+  "BBAI": {
+    "sector": "Technology",
+    "industry": "Information Technology Services"
+  },
+  "BN": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "BOTZ": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Global"
+  },
+  "BTI": {
+    "sector": "Consumer Defensive",
+    "industry": "Tobacco"
+  },
+  "BXSL": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "C": {
+    "sector": "Financial Services",
+    "industry": "Banks - Diversified"
+  },
+  "CIBR": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Global"
+  },
+  "COPX": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "CPNG": {
+    "sector": "Consumer Cyclical",
+    "industry": "Specialty Retail"
+  },
+  "CPRT": {
+    "sector": "Industrials",
+    "industry": "Specialty Business Services"
+  },
+  "CRCL": {
+    "sector": "Financial Services",
+    "industry": "Financial - Capital Markets"
+  },
+  "CSCO": {
+    "sector": "Technology",
+    "industry": "Communication Equipment"
+  },
+  "CUBE": {
+    "sector": "Real Estate",
+    "industry": "REIT - Industrial"
+  },
+  "CVS": {
+    "sector": "Healthcare",
+    "industry": "Medical - Healthcare Plans"
+  },
+  "CVX": {
+    "sector": "Energy",
+    "industry": "Oil & Gas Integrated"
+  },
+  "DELL": {
+    "sector": "Technology",
+    "industry": "Computer Hardware"
+  },
+  "DGRO": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Income"
+  },
+  "DIVO": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Income"
+  },
+  "DLR": {
+    "sector": "Real Estate",
+    "industry": "REIT - Specialty"
+  },
+  "FIGR": {
+    "sector": "Financial Services",
+    "industry": "Financial - Capital Markets"
+  },
+  "FORM": {
+    "sector": "Technology",
+    "industry": "Semiconductors"
+  },
+  "GLDM": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "HOOD": {
+    "sector": "Financial Services",
+    "industry": "Financial - Capital Markets"
+  },
+  "HPQ": {
+    "sector": "Technology",
+    "industry": "Computer Hardware"
+  },
+  "HTGC": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "IEF": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Bonds"
+  },
+  "INDA": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Global"
+  },
+  "IREN": {
+    "sector": "Financial Services",
+    "industry": "Financial - Capital Markets"
+  },
+  "ISRG": {
+    "sector": "Healthcare",
+    "industry": "Medical - Devices"
+  },
+  "JEPI": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Income"
+  },
+  "JEPQ": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Income"
+  },
+  "KO": {
+    "sector": "Consumer Defensive",
+    "industry": "Beverages - Non-Alcoholic"
+  },
+  "KR": {
+    "sector": "Consumer Defensive",
+    "industry": "Grocery Stores"
+  },
+  "MAGS": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Global"
+  },
+  "MAIN": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "META": {
+    "sector": "Communication Services",
+    "industry": "Internet Content & Information"
+  },
+  "MO": {
+    "sector": "Consumer Defensive",
+    "industry": "Tobacco"
+  },
+  "MRVL": {
+    "sector": "Technology",
+    "industry": "Semiconductors"
+  },
+  "NEE": {
+    "sector": "Utilities",
+    "industry": "Regulated Electric"
+  },
+  "NFLX": {
+    "sector": "Communication Services",
+    "industry": "Entertainment"
+  },
+  "NKE": {
+    "sector": "Consumer Cyclical",
+    "industry": "Apparel - Footwear & Accessories"
+  },
+  "NU": {
+    "sector": "Financial Services",
+    "industry": "Banks - Diversified"
+  },
+  "NVDA": {
+    "sector": "Technology",
+    "industry": "Semiconductors"
+  },
+  "O": {
+    "sector": "Real Estate",
+    "industry": "REIT - Retail"
+  },
+  "OHI": {
+    "sector": "Real Estate",
+    "industry": "REIT - Healthcare Facilities"
+  },
+  "OKE": {
+    "sector": "Energy",
+    "industry": "Oil & Gas Midstream"
+  },
+  "ORCL": {
+    "sector": "Technology",
+    "industry": "Software - Infrastructure"
+  },
+  "OZEM": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "PANW": {
+    "sector": "Technology",
+    "industry": "Software - Infrastructure"
+  },
+  "PAVE": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Global"
+  },
+  "PCG": {
+    "sector": "Utilities",
+    "industry": "Regulated Electric"
+  },
+  "PFE": {
+    "sector": "Healthcare",
+    "industry": "Drug Manufacturers - General"
+  },
+  "PLTR": {
+    "sector": "Technology",
+    "industry": "Software - Infrastructure"
+  },
+  "QCOM": {
+    "sector": "Technology",
+    "industry": "Semiconductors"
+  },
+  "QQQM": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Global"
+  },
+  "REMX": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "RSG": {
+    "sector": "Industrials",
+    "industry": "Waste Management"
+  },
+  "SCHD": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Income"
+  },
+  "SGOV": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Bonds"
+  },
+  "SHLD": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Global"
+  },
+  "SIL": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "SMR": {
+    "sector": "Utilities",
+    "industry": "Renewable Utilities"
+  },
+  "SOXX": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "SPYM": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Global"
+  },
+  "STAG": {
+    "sector": "Real Estate",
+    "industry": "REIT - Industrial"
+  },
+  "T": {
+    "sector": "Communication Services",
+    "industry": "Telecommunications Services"
+  },
+  "TEM": {
+    "sector": "Healthcare",
+    "industry": "Medical - Healthcare Information Services"
+  },
+  "TLT": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Bonds"
+  },
+  "TOST": {
+    "sector": "Technology",
+    "industry": "Software - Infrastructure"
+  },
+  "TSLA": {
+    "sector": "Consumer Cyclical",
+    "industry": "Auto - Manufacturers"
+  },
+  "URA": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "V": {
+    "sector": "Financial Services",
+    "industry": "Financial - Credit Services"
+  },
+  "VNQ": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "VRT": {
+    "sector": "Industrials",
+    "industry": "Electrical Equipment & Parts"
+  },
+  "VXUS": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Global"
+  },
+  "VZ": {
+    "sector": "Communication Services",
+    "industry": "Telecommunications Services"
+  },
+  "WFC": {
+    "sector": "Financial Services",
+    "industry": "Banks - Diversified"
+  },
+  "XLB": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "XLC": {
+    "sector": "Financial Services",
+    "industry": "Asset Management - Bonds"
+  },
+  "XLE": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "XLF": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "XLP": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "XLRE": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "XLU": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "XLY": {
+    "sector": "Financial Services",
+    "industry": "Asset Management"
+  },
+  "XOM": {
+    "sector": "Energy",
+    "industry": "Oil & Gas Integrated"
+  }
+}

--- a/config/fmpcat_cache.json
+++ b/config/fmpcat_cache.json
@@ -1,8 +1,4 @@
 {
-  "1321.T": {
-    "sector": "",
-    "industry": ""
-  },
   "1489.T": {
     "sector": "Financial Services",
     "industry": "Asset Management - Income"

--- a/internal/fmpcat/resolver.go
+++ b/internal/fmpcat/resolver.go
@@ -114,10 +114,19 @@ func (r *Resolver) saveCache() error {
 		return err
 	}
 	defer f.Close()
+	// 빈 결과(미커버/미지원 통화)는 파일에 영구화하지 않는다(노이즈 방지).
+	// 인메모리 캐시엔 남아 같은 실행 내 재조회는 막고, 다음 실행에 1회 재시도된다.
+	out := make(map[string]entry, len(r.cache))
+	for k, v := range r.cache {
+		if v.Sector == "" && v.Industry == "" {
+			continue
+		}
+		out[k] = v
+	}
 	enc := json.NewEncoder(f)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
-	return enc.Encode(r.cache)
+	return enc.Encode(out)
 }
 
 func fmpFetch() func(string) (string, string, error) {

--- a/internal/fmpcat/resolver_test.go
+++ b/internal/fmpcat/resolver_test.go
@@ -102,6 +102,20 @@ func TestResolve_ErrorNegativeCache(t *testing.T) {
 	assert.Equal(t, 1, calls, "실패 심볼은 같은 실행 내 1회만")
 }
 
+// 빈 결과(미커버/미지원)는 파일에 영구화하지 않는다(노이즈 방지).
+func TestSaveCache_OmitsEmptyEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fmpcat_cache.json")
+	r := &Resolver{cache: map[string]entry{
+		"AAPL":   {Sector: "Technology", Industry: "Consumer Electronics"},
+		"1321.T": {Sector: "", Industry: ""},
+	}, cachePath: path}
+	require.NoError(t, r.saveCache())
+	data, _ := os.ReadFile(path)
+	assert.Contains(t, string(data), "AAPL")
+	assert.NotContains(t, string(data), "1321.T", "빈 항목은 파일에 안 씀")
+}
+
 func TestCacheSaveLoad_Roundtrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "fmpcat_cache.json")


### PR DESCRIPTION
## Summary
FMP 회사 프로필 조회 결과(`config/fmpcat_cache.json`)를 git 추적해 재실행/타 환경에서 FMP 재호출을 피한다.

- 심볼 104개(미국·일본), 103개 채워짐
- 해외 ETF(`1321.T` 닛케이225)만 공란(FMP 미커버, 설계대로)

## Test plan
- [x] backfill 실행으로 생성된 캐시(미국 BAC/AAPL/NEE, 일본 1489.T 등 검증 완료)