### PR TITLE
refactor(summary): 나라별 섹터 비중을 종목별 현황 위로 이동

### DIFF
--- a/internal/summary/formats.go
+++ b/internal/summary/formats.go
@@ -47,7 +47,7 @@ func (g *Generator) collectHeaderColors(monthlyStart, trendStart, stockStart int
 // collectDashboardFormats 는 대시보드 숫자 포맷 요청을 pendingRequests 에 수집한다.
 // (Python _collect_dashboard_formats, py:708-777)
 func (g *Generator) collectDashboardFormats(monthlyStart, metricsStart, insightsStart,
-	trendStart, stockStart, totalRows int) {
+	trendStart, trendEnd, stockStart, totalRows int) {
 	_ = insightsStart // 섹션 4/5 는 collectMetricsFormats 에서 행별 처리.
 	sid := g.dashboardSheetID
 	build := sheets.BuildNumberFormatRequests
@@ -78,8 +78,9 @@ func (g *Generator) collectDashboardFormats(monthlyStart, metricsStart, insights
 			build(sid, monthlyFormats, monthlyStart+1, monthlyDataEnd)...)
 	}
 
-	// 섹션 6: 월별 성과 추이 (trend_start+1 ~ stock_start-2).
-	trendDataEnd := stockStart - 2
+	// 섹션 6: 월별 성과 추이 (trend_start+1 ~ trend_end-1).
+	// (나라별 섹터 섹션이 추이와 종목별 사이에 끼므로 stockStart 로 추정하지 않고 trendEnd 사용.)
+	trendDataEnd := trendEnd - 1
 	if trendDataEnd > trendStart {
 		trendFormats := []sheets.ColumnFormat{
 			{Col: 2, Pattern: "#,##0"},                  // B: 매도건수

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -103,22 +103,24 @@ func (g *Generator) GenerateAll(ctx context.Context, trades []model.Trade) error
 	if currentRow, err = g.writeMonthlyTrend(ctx, trades, currentRow); err != nil {
 		return err
 	}
-	currentRow++ // 빈 행
-	stockStart := currentRow
-	if currentRow, err = g.writeStockSummary(ctx, trades, currentRow); err != nil {
-		return err
-	}
-	stockEnd := currentRow // 종목별 현황 끝(나라별 섹션 추가 전 — 종목 포맷 범위 보존)
+	trendEnd := currentRow // 월별 성과 추이 끝(차트/포맷 범위 — 아래 나라별 섹션 삽입 전 보존)
 
 	currentRow++ // 빈 행
 	if currentRow, err = g.writeCountrySectorWeight(ctx, trades, currentRow); err != nil {
 		return err
 	}
 
+	currentRow++             // 빈 행
+	stockStart := currentRow // 종목별 현황(가장 큼)은 맨 아래
+	if currentRow, err = g.writeStockSummary(ctx, trades, currentRow); err != nil {
+		return err
+	}
+	stockEnd := currentRow
+
 	// 포맷/색상 요청을 pendingRequests 에 수집. (Python generate_all py:69-73)
 	g.collectHeaderColors(monthlyStart, trendStart, stockStart)
 	g.collectDashboardFormats(monthlyStart, metricsStart, insightsStart,
-		trendStart, stockStart, stockEnd)
+		trendStart, trendEnd, stockStart, stockEnd)
 
 	// 차트용 거래건수 데이터 작성 (포맷 요청도 수집됨). (Python py:76)
 	if err := g.writeTradeCountData(ctx, trades); err != nil {
@@ -131,7 +133,7 @@ func (g *Generator) GenerateAll(ctx context.Context, trades []model.Trade) error
 	}
 
 	// 차트 생성. (Python py:81-85)
-	if err := g.createCharts(ctx, trendStart, stockStart-1); err != nil {
+	if err := g.createCharts(ctx, trendStart, trendEnd); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
종목별 현황(326행, 가장 큼)을 맨 아래로 보내고 **나라별 섹터 비중**을 그 위로 옮겨 접근성을 높인다.

새 섹션 순서: 포트폴리오 → 월별 성과 → 투자 지표 → 매매 인사이트 → 월별 성과 추이 → **나라별 섹터 비중** → 종목별 현황

## Changes
- `GenerateAll`: `writeCountrySectorWeight` 를 `writeStockSummary` 앞으로
- 추이 섹션 끝(`trendEnd`)을 명시 추적해 `collectDashboardFormats`/`createCharts` 에 전달
  - 나라별 섹션이 추이↔종목별 사이에 끼면서 기존 `stockStart-2` 추정이 깨지므로 trendEnd 직접 전달로 교정

## Test plan
- [x] `go build`/`vet`/`gofmt`/`go test ./...` 통과
- [x] `make run` 실 실행: 추이 → 나라별 섹터(rows=33, 3국) → 종목별 현황(326) 순서 + 차트 9개 확인