### PR TITLE
feat(summary): 나라별 섹터 비중에서 ETF 를 카테고리로 세분화

### DIFF
--- a/internal/summary/country_sector.go
+++ b/internal/summary/country_sector.go
@@ -28,6 +28,16 @@ type countrySectorGroup struct {
 	Rows     []countrySectorRow // 매수금액 내림차순
 }
 
+// sectorKey 는 집계 라벨을 정한다. ETF 는 한 덩어리로 뭉치지 않도록 산업(OpenAI category)으로
+// "ETF·{category}" 세분화한다(예 "ETF·반도체"/"ETF·미국주식"). 산업이 빈 미분류 ETF 는 "ETF".
+// 일반 종목은 섹터(KIS 업종 / FMP 영문) 그대로.
+func sectorKey(sector, industry string) string {
+	if sector == "ETF" && industry != "" {
+		return "ETF·" + industry
+	}
+	return sector
+}
+
 // countryLabel 은 통화 코드를 국가 라벨로 바꾼다. 미정의 통화는 코드 그대로.
 func countryLabel(currency string) string {
 	switch currency {
@@ -65,21 +75,22 @@ func countrySectorGroups(trades []model.Trade) []countrySectorGroup {
 	type agg struct {
 		buy, sell float64
 	}
-	// currency -> sector -> agg
+	// currency -> sectorKey -> agg
 	byCur := map[string]map[string]*agg{}
 	for _, t := range trades {
 		if t.Sector == "" {
 			continue
 		}
+		key := sectorKey(t.Sector, t.Industry)
 		sectors, ok := byCur[t.Currency]
 		if !ok {
 			sectors = map[string]*agg{}
 			byCur[t.Currency] = sectors
 		}
-		a := sectors[t.Sector]
+		a := sectors[key]
 		if a == nil {
 			a = &agg{}
-			sectors[t.Sector] = a
+			sectors[key] = a
 		}
 		switch t.TradeType {
 		case "매수":

--- a/internal/summary/country_sector_test.go
+++ b/internal/summary/country_sector_test.go
@@ -60,6 +60,29 @@ func TestCountrySectorGroups(t *testing.T) {
 	assert.InDelta(t, 1.0, jp.Rows[0].Weight, 1e-9)
 }
 
+// 국내 ETF 는 섹터 대신 산업(OpenAI category)으로 "ETF·{category}" 세분화한다.
+// 산업이 빈 미분류 ETF 는 "ETF" 로 남는다. 일반 종목 섹터는 그대로.
+func TestCountrySectorGroups_ETFSubdividedByIndustry(t *testing.T) {
+	trades := []model.Trade{
+		{Currency: "KRW", Sector: "ETF", Industry: "반도체", TradeType: "매수", AmountKRW: 3_000_000},
+		{Currency: "KRW", Sector: "ETF", Industry: "미국주식", TradeType: "매수", AmountKRW: 1_000_000},
+		{Currency: "KRW", Sector: "ETF", Industry: "", TradeType: "매수", AmountKRW: 500_000}, // 미분류 → "ETF"
+		{Currency: "KRW", Sector: "금융", TradeType: "매수", AmountKRW: 500_000},
+	}
+	groups := countrySectorGroups(trades)
+	if !assert.Len(t, groups, 1) {
+		return
+	}
+	byLabel := map[string]float64{}
+	for _, r := range groups[0].Rows {
+		byLabel[r.Sector] = r.Buy
+	}
+	assert.Equal(t, 3_000_000.0, byLabel["ETF·반도체"])
+	assert.Equal(t, 1_000_000.0, byLabel["ETF·미국주식"])
+	assert.Equal(t, 500_000.0, byLabel["ETF"]) // 미분류 ETF
+	assert.Equal(t, 500_000.0, byLabel["금융"])  // 일반 종목 섹터 그대로
+}
+
 // 섹터가 모두 빈 국가는 제외된다.
 func TestCountrySectorGroups_SkipsEmptyCountry(t *testing.T) {
 	trades := []model.Trade{


### PR DESCRIPTION
## Summary
국내 ETF 가 "ETF" 한 덩어리(보유의 85%)로 뭉쳐 정보가 없던 것을, 산업(#76 OpenAI category)으로 **"ETF·{category}"** 세분화한다.

예: `ETF·반도체`, `ETF·미국주식`, `ETF·채권`, `ETF·배당` … 미분류 ETF 는 `ETF`, 일반 종목 섹터(금융/통신 등)는 그대로.

## Changes
- `sectorKey(sector, industry)`: `Sector=="ETF" && Industry!=""` → `"ETF·"+industry` 를 집계 키로 사용
- 국내 ETF 만 해당(해외 Sector 는 FMP 영문이라 "ETF" 아님)

## Test plan
- [x] `go test ./...` 통과 (신규 `TestCountrySectorGroups_ETFSubdividedByIndustry`)
- [x] `make run` 실 실행: 나라별 섹터 비중 행 33→57(국내 ETF 분할), 차트 9개, 오류 없음