### PR TITLE
chore: Python 잔여물 정리 및 stale 참조 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ token.dat
 *.mst
 *.zip
 
-*.egg-info
 .history
 reports
 logs
@@ -54,6 +53,3 @@ input/
 # Go
 /atj
 *.test
-# Python (백업 레퍼런스)
-__pycache__/
-*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,8 +214,8 @@ input/
 1. `internal/parser/` 에 새 파서 파일 생성
 2. `Parser` 인터페이스(`Name`/`CanParse`/`Parse`) 구현
 3. `internal/parser/registry.go` 의 `registry` 슬라이스에 등록
-4. 테스트 + `testdata/` 픽스처 추가
-5. `tests/test_parsers.py` 에 테스트 추가
+4. `internal/parser/{broker}_test.go` 테스트 + 루트 `testdata/` CSV 픽스처 추가
+5. `make test` 로 전체 통과 확인
 
 ### Text Encoding (Korean Content)
 


### PR DESCRIPTION
## 배경

Go 포팅이 끝난 뒤에도 로컬에 Python 시절 산출물이 남아 있었다. `git ls-files` 로 확인한 결과 **Git 이 추적하는 Python 파일은 0개** — 코드 자체는 포팅 커밋에서 이미 제거됐고, untracked 산출물과 문서의 stale 참조만 남은 상태였다.

### 삭제 (전부 git 미추적, 재생성 가능)

| 대상 | 크기 | 내용 |
|---|---|---|
| `.venv/` | 127M | Python 3.13 가상환경 |
| `modules/`, `tests/` | 448K | `.pyc` 캐시 20개만 잔존 (소스는 이미 제거됨) |
| `__pycache__/`, `.pytest_cache/` | 44K | 캐시 |
| `*.egg-info/` (2개) | 48K | pip editable install 메타데이터 |

### 수정 (커밋에 포함된 2개 파일)

- `.gitignore`: Python 전용 규칙 제거 (`__pycache__/`, `*.pyc`, `*.egg-info`)
- `CLAUDE.md`: "새 파서 추가" 절차의 `tests/test_parsers.py` 참조를 Go 경로(`internal/parser/{broker}_test.go` + `make test`)로 교체

### 유지한 것

- `README.md` / `CLAUDE.md` 상단의 "Python 원본 → Go 포팅" 이력 문구 (맥락 설명이므로 유지)
- `docs/done/` 아카이브 문서 (완료 기록)
- `.idea/` IDE 설정 — 아직 `PYTHON_MODULE` + `Python SDK` 로 잡혀 있으나, IDE 가 덮어쓰며 충돌할 수 있어 손대지 않음. PyCharm/GoLand 에서 Go 모듈로 재설정 필요 (git 미추적)

### 후속 과제

- `docs/start/2_samsung_*.md` — **미구현** 삼성증권 파서 PRD 3개가 Python 코드 예시 기준으로 작성돼 있음. 실제 구현 전에 Go 기준으로 다시 써야 한다.

## 테스트 계획

- [x] `go build ./...` 통과
- [x] `go vet ./...` 통과
- [x] `go test ./...` 통과 (11개 패키지 전부 ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)