### PR TITLE
fix: Sheets 읽기 429 재시도 누락 및 대시보드 부분 데이터 재작성 방지

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,17 @@ internal/
 
 **internal/sheets** (`client.go`, `format.go`, `chart.go`):
 - Google Sheets API v4 래퍼(서비스계정 인증), 값 I/O, 포맷/색상/필터/차트, 레이트리밋 재시도(`executeWithRetry`)
+- ⚠️ **모든** API 호출(읽기 `Spreadsheets.Get`/`Values.Get`, 쓰기 `values.update`/`batchUpdate`)은
+  `executeWithRetry` 를 거쳐야 한다. Sheets 쿼터는 **읽기/쓰기 각각 분당 60회(프로젝트·사용자 단위)** 이고
+  버킷이 비면 최대 60초를 기다려야 회복되므로, 재시도 누적 대기가 60초를 넘도록 `maxRetries=6`
+  (1+2+4+8+16+32≈63초)으로 잡혀 있다(`retry_test.go` 의 `TestRetryWaitBudgetCoversQuotaWindow` 가 이 불변식을 지킨다).
+- `NewWithEndpoint` 는 테스트용 fake 서버(httptest)를 향하는 무인증 클라이언트다.
 
 **internal/writer** (`writer.go`, `headers.go`, `reader.go`):
 - `EnsureSheetExists`, `GetExistingKeys`(중복키), `InsertTrades`(포맷 적용), `ReadAllTrades`(대시보드 입력), 국내/해외 헤더 상수
+- `ReadAllTrades` 는 읽기 쿼터를 아끼기 위해 **시트당 그리드 조회 1회**(`A1:Q10000`, 헤더=1행)만 쓴다.
+  또한 조회 실패를 스킵하지 않고 **에러로 전파**한다 — 일부 시트만 실패한 채 진행하면 대시보드가
+  부분 데이터로 통째로 재작성되어 기존 내용을 잃는다.
 
 **internal/summary** (`summary.go`, `sections.go`, `insights.go`, `formats.go`, `charts.go`):
 - 단일 "대시보드" 시트 생성: 포트폴리오/월별/종목별 요약 + 투자지표(섹터별 투자비중 포함)/매매인사이트/월별추이 + basic/pie 차트. 매 실행 초기화 후 재작성

--- a/internal/sheets/client.go
+++ b/internal/sheets/client.go
@@ -24,10 +24,22 @@ type Client struct {
 
 // New 는 서비스 계정 키로 인증된 Client 를 생성한다. (Python __init__/_connect)
 func New(ctx context.Context, spreadsheetID, serviceAccountPath string) (*Client, error) {
-	svc, err := gsheets.NewService(ctx,
+	return newClient(ctx, spreadsheetID,
 		option.WithCredentialsFile(serviceAccountPath),
 		option.WithScopes(scope),
 	)
+}
+
+// NewWithEndpoint 는 지정한 엔드포인트를 향하는 무인증 Client 를 만든다(테스트용 fake 서버).
+func NewWithEndpoint(ctx context.Context, spreadsheetID, endpoint string) (*Client, error) {
+	return newClient(ctx, spreadsheetID,
+		option.WithEndpoint(endpoint),
+		option.WithoutAuthentication(),
+	)
+}
+
+func newClient(ctx context.Context, spreadsheetID string, opts ...option.ClientOption) (*Client, error) {
+	svc, err := gsheets.NewService(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("Google Sheets API 연결 실패: %w", err)
 	}
@@ -40,7 +52,12 @@ func New(ctx context.Context, spreadsheetID, serviceAccountPath string) (*Client
 
 // GetSpreadsheetMetadata 는 스프레드시트 전체 메타데이터를 반환한다. (Python get_spreadsheet_metadata)
 func (c *Client) GetSpreadsheetMetadata(ctx context.Context) (*gsheets.Spreadsheet, error) {
-	ss, err := c.service.Spreadsheets.Get(c.spreadsheetID).Context(ctx).Do()
+	var ss *gsheets.Spreadsheet
+	err := executeWithRetry(ctx, func() error {
+		var err error
+		ss, err = c.service.Spreadsheets.Get(c.spreadsheetID).Context(ctx).Do()
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("스프레드시트 메타데이터 조회 실패: %w", err)
 	}
@@ -118,10 +135,15 @@ func (c *Client) InsertColumns(ctx context.Context, sheetName string, startIdx, 
 // sheetName 과 rangeA1(예: "A2:O10000")을 받아 내부에서 "sheetName!rangeA1" 로 조합한다.
 func (c *Client) GetRawGridData(ctx context.Context, sheetName, rangeA1 string) (*gsheets.GridData, error) {
 	rangeName := fmt.Sprintf("%s!%s", sheetName, rangeA1)
-	resp, err := c.service.Spreadsheets.Get(c.spreadsheetID).
-		Ranges(rangeName).
-		Fields("sheets.data.rowData.values(effectiveValue,formattedValue)").
-		Context(ctx).Do()
+	var resp *gsheets.Spreadsheet
+	err := executeWithRetry(ctx, func() error {
+		var err error
+		resp, err = c.service.Spreadsheets.Get(c.spreadsheetID).
+			Ranges(rangeName).
+			Fields("sheets.data.rowData.values(effectiveValue,formattedValue)").
+			Context(ctx).Do()
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("시트 GridData 조회 실패: %w", err)
 	}
@@ -135,7 +157,12 @@ func (c *Client) GetRawGridData(ctx context.Context, sheetName, rangeA1 string) 
 
 // GetValues 는 지정한 A1 범위(예: "SheetName!A1:Z")의 값을 반환한다. (Python get_sheet_data)
 func (c *Client) GetValues(ctx context.Context, rangeA1 string) ([][]interface{}, error) {
-	resp, err := c.service.Spreadsheets.Values.Get(c.spreadsheetID, rangeA1).Context(ctx).Do()
+	var resp *gsheets.ValueRange
+	err := executeWithRetry(ctx, func() error {
+		var err error
+		resp, err = c.service.Spreadsheets.Values.Get(c.spreadsheetID, rangeA1).Context(ctx).Do()
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("시트 데이터 조회 실패: %w", err)
 	}
@@ -145,9 +172,12 @@ func (c *Client) GetValues(ctx context.Context, rangeA1 string) ([][]interface{}
 // UpdateCells 는 지정한 A1 범위에 값을 기록한다(USER_ENTERED). (Python update_cells)
 func (c *Client) UpdateCells(ctx context.Context, rangeA1 string, data [][]interface{}) error {
 	vr := &gsheets.ValueRange{Values: data}
-	_, err := c.service.Spreadsheets.Values.Update(c.spreadsheetID, rangeA1, vr).
-		ValueInputOption("USER_ENTERED").
-		Context(ctx).Do()
+	err := executeWithRetry(ctx, func() error {
+		_, err := c.service.Spreadsheets.Values.Update(c.spreadsheetID, rangeA1, vr).
+			ValueInputOption("USER_ENTERED").
+			Context(ctx).Do()
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("셀 업데이트 실패: %w", err)
 	}
@@ -164,7 +194,10 @@ func (c *Client) BatchUpdateValues(ctx context.Context, ranges map[string][][]in
 		ValueInputOption: "USER_ENTERED",
 		Data:             data,
 	}
-	_, err := c.service.Spreadsheets.Values.BatchUpdate(c.spreadsheetID, req).Context(ctx).Do()
+	err := executeWithRetry(ctx, func() error {
+		_, err := c.service.Spreadsheets.Values.BatchUpdate(c.spreadsheetID, req).Context(ctx).Do()
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("배치 업데이트 실패: %w", err)
 	}
@@ -173,8 +206,11 @@ func (c *Client) BatchUpdateValues(ctx context.Context, ranges map[string][][]in
 
 // ClearValues 는 지정한 A1 범위(예: "SheetName!A2:Z")의 값을 비운다. (Python clear_sheet)
 func (c *Client) ClearValues(ctx context.Context, rangeA1 string) error {
-	_, err := c.service.Spreadsheets.Values.Clear(c.spreadsheetID, rangeA1, &gsheets.ClearValuesRequest{}).
-		Context(ctx).Do()
+	err := executeWithRetry(ctx, func() error {
+		_, err := c.service.Spreadsheets.Values.Clear(c.spreadsheetID, rangeA1, &gsheets.ClearValuesRequest{}).
+			Context(ctx).Do()
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("시트 데이터 삭제 실패: %w", err)
 	}

--- a/internal/sheets/format.go
+++ b/internal/sheets/format.go
@@ -31,18 +31,42 @@ type ColorRange struct {
 	Color    *gsheets.Color
 }
 
+// maxRetries 는 최초 1회 외에 추가로 시도하는 횟수다.
+//
+// Sheets 쿼터는 "분당 60회"(read/write 각각)라 버킷이 비면 **최대 60초를 기다려야**
+// 회복된다. 따라서 재시도 대기의 누적 합이 60초를 넘도록 잡는다
+// (1+2+4+8+16+32 ≈ 63초). retryWaitBudget 테스트가 이 불변식을 지킨다.
+const maxRetries = 6
+
+// retryWait 은 attempt(0-based) 회차의 백오프 대기 시간을 반환한다.
+// min(2**attempt + random(0,1), 64) 초 — Python _execute_with_retry 와 동일한 곡선.
+func retryWait(attempt int) time.Duration {
+	wait := math.Min(math.Pow(2, float64(attempt))+rand.Float64(), 64)
+	return time.Duration(wait * float64(time.Second))
+}
+
+// retrySleep 은 ctx 취소를 존중하며 d 만큼 대기한다. 테스트에서 교체 가능하도록 변수다.
+var retrySleep = func(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 // executeWithRetry 는 API 요청을 실행하고 429/5xx 에러 시 지수 백오프로 재시도한다.
-// (Python _execute_with_retry, max_retries 기본 3)
+// (Python _execute_with_retry)
 //
-// Python 정책(modules/google_sheets_client.py:73-87):
-//   - 총 시도 = max_retries + 1 (즉 최초 1회 + 재시도 3회).
-//   - 재시도 가능 조건: HttpError status == 429 이고 attempt < max_retries.
-//   - 대기 = min(2**attempt + random(0,1), 64) 초.
+//   - 총 시도 = maxRetries + 1.
+//   - 재시도 가능 조건: HTTP status 429(쿼터 초과) 또는 일시적 5xx.
+//   - 그 외 에러는 즉시 반환.
 //
-// Go 포팅에서는 429 외에 일시적 5xx(500/502/503/504)도 재시도 대상으로 포함한다
-// (배치 batchUpdate 의 안정성을 위한 보수적 확장). 그 외 에러는 즉시 반환.
+// 읽기/쓰기 **모든** Sheets 호출이 이 함수를 거쳐야 한다. 하나라도 빠지면 쿼터 초과 시
+// 그 호출만 즉시 실패해 상위 로직이 부분 데이터로 진행하게 된다.
 func executeWithRetry(ctx context.Context, fn func() error) error {
-	const maxRetries = 3
 	var lastErr error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		lastErr = fn()
@@ -50,13 +74,8 @@ func executeWithRetry(ctx context.Context, fn func() error) error {
 			return nil
 		}
 		if attempt < maxRetries && isRetryable(lastErr) {
-			wait := math.Min(math.Pow(2, float64(attempt))+rand.Float64(), 64)
-			timer := time.NewTimer(time.Duration(wait * float64(time.Second)))
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return ctx.Err()
-			case <-timer.C:
+			if err := retrySleep(ctx, retryWait(attempt)); err != nil {
+				return err
 			}
 			continue
 		}

--- a/internal/sheets/retry_test.go
+++ b/internal/sheets/retry_test.go
@@ -1,0 +1,188 @@
+package sheets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+)
+
+// stubRetrySleep 은 테스트 동안 실제 대기를 없애고 호출된 대기 시간을 기록한다.
+func stubRetrySleep(t *testing.T) *[]time.Duration {
+	t.Helper()
+	orig := retrySleep
+	var waits []time.Duration
+	retrySleep = func(ctx context.Context, d time.Duration) error {
+		waits = append(waits, d)
+		return nil
+	}
+	t.Cleanup(func() { retrySleep = orig })
+	return &waits
+}
+
+func rateLimitErr() error {
+	return &googleapi.Error{Code: 429, Message: "Quota exceeded for quota metric 'Read requests'"}
+}
+
+// Sheets 쿼터는 분당 리셋이므로, 재시도 대기 누적이 60초 이상이어야 버킷 회복을 기다릴 수 있다.
+func TestRetryWaitBudgetCoversQuotaWindow(t *testing.T) {
+	var total time.Duration
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		total += retryWait(attempt)
+	}
+	assert.GreaterOrEqual(t, total, 60*time.Second,
+		"재시도 누적 대기가 쿼터 창(60초)보다 짧으면 429 를 넘길 수 없다")
+}
+
+func TestExecuteWithRetryRetriesOnRateLimit(t *testing.T) {
+	waits := stubRetrySleep(t)
+	calls := 0
+
+	err := executeWithRetry(context.Background(), func() error {
+		calls++
+		return rateLimitErr()
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, maxRetries+1, calls, "최초 1회 + maxRetries 회 재시도해야 한다")
+	assert.Len(t, *waits, maxRetries)
+}
+
+func TestExecuteWithRetrySucceedsAfterRateLimit(t *testing.T) {
+	stubRetrySleep(t)
+	calls := 0
+
+	err := executeWithRetry(context.Background(), func() error {
+		calls++
+		if calls < 3 {
+			return rateLimitErr()
+		}
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestExecuteWithRetryStopsOnNonRetryable(t *testing.T) {
+	stubRetrySleep(t)
+	calls := 0
+
+	err := executeWithRetry(context.Background(), func() error {
+		calls++
+		return &googleapi.Error{Code: 403, Message: "forbidden"}
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls, "403 은 재시도 대상이 아니다")
+}
+
+func TestExecuteWithRetryHonorsContextCancel(t *testing.T) {
+	orig := retrySleep
+	retrySleep = func(ctx context.Context, d time.Duration) error { return context.Canceled }
+	t.Cleanup(func() { retrySleep = orig })
+
+	err := executeWithRetry(context.Background(), func() error { return rateLimitErr() })
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// isRetryable 은 래핑된 에러(fmt.Errorf %w)에서도 429 를 인식해야 한다.
+func TestIsRetryableUnwrapsWrappedError(t *testing.T) {
+	assert.True(t, isRetryable(fmt.Errorf("시트 데이터 조회 실패: %w", rateLimitErr())))
+	assert.False(t, isRetryable(errors.New("plain")))
+}
+
+// ── 읽기 경로 재시도 (fake Sheets 엔드포인트) ──────────────────────
+
+// newFakeClient 는 httptest 서버를 Sheets 엔드포인트로 쓰는 Client 를 만든다.
+func newFakeClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	c, err := NewWithEndpoint(context.Background(), "test-sheet", srv.URL)
+	require.NoError(t, err)
+	return c
+}
+
+func writeQuotaExceeded(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusTooManyRequests)
+	_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Quota exceeded","status":"RESOURCE_EXHAUSTED"}}`))
+}
+
+// GetValues 는 429 를 만나면 재시도해서 성공해야 한다(현재는 재시도 없이 즉시 실패).
+func TestGetValuesRetriesOnRateLimit(t *testing.T) {
+	stubRetrySleep(t)
+	var hits int32
+
+	c := newFakeClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&hits, 1) == 1 {
+			writeQuotaExceeded(w)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"range":"A1:Q1","values":[["일자","구분"]]}`))
+	})
+
+	vals, err := c.GetValues(context.Background(), "시트!A1:Q1")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits))
+	assert.Equal(t, [][]interface{}{{"일자", "구분"}}, vals)
+}
+
+// GetRawGridData / GetSpreadsheetMetadata 도 동일하게 재시도해야 한다.
+func TestGridAndMetadataRetryOnRateLimit(t *testing.T) {
+	stubRetrySleep(t)
+	var hits int32
+
+	c := newFakeClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&hits, 1)%2 == 1 {
+			writeQuotaExceeded(w)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"sheets":[{"properties":{"title":"시트","sheetId":7},` +
+			`"data":[{"rowData":[{"values":[{"formattedValue":"2026-01-02"}]}]}]}]}`))
+	})
+
+	grid, err := c.GetRawGridData(context.Background(), "시트", "A1:Q10")
+	require.NoError(t, err)
+	require.Len(t, grid.RowData, 1)
+
+	meta, err := c.GetSpreadsheetMetadata(context.Background())
+	require.NoError(t, err)
+	require.Len(t, meta.Sheets, 1)
+
+	assert.Equal(t, int32(4), atomic.LoadInt32(&hits), "각 호출이 1회씩 재시도되어야 한다")
+}
+
+// 값 쓰기(ClearValues/UpdateCells/BatchUpdateValues)도 쓰기 쿼터(분당 60)를 공유하므로 재시도 대상이다.
+func TestValueWritesRetryOnRateLimit(t *testing.T) {
+	stubRetrySleep(t)
+	var hits int32
+
+	c := newFakeClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&hits, 1)%2 == 1 {
+			writeQuotaExceeded(w)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	ctx := context.Background()
+	require.NoError(t, c.ClearValues(ctx, "시트!A1:Z"))
+	require.NoError(t, c.UpdateCells(ctx, "시트!A1", [][]interface{}{{"a"}}))
+	require.NoError(t, c.BatchUpdateValues(ctx, map[string][][]interface{}{"시트!A1": {{"a"}}}))
+
+	assert.Equal(t, int32(6), atomic.LoadInt32(&hits))
+}

--- a/internal/writer/reader.go
+++ b/internal/writer/reader.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -11,13 +12,23 @@ import (
 	gsheets "google.golang.org/api/sheets/v4"
 )
 
+// tradeGridRange 는 매매일지 시트를 헤더 포함 1회에 읽는 범위다.
+// 국내 12컬럼(A~L), 해외 17컬럼(A~Q) 공통.
+const tradeGridRange = "A1:Q10000"
+
 // ReadAllTrades 는 모든 매매일지 시트에서 Trade 리스트를 읽어 반환한다.
 // 헤더 행(1행)을 검증하여 매매일지 시트만 식별한다. (Python read_all_trades)
 //
 //   - DomesticHeaders 일치 → 국내
 //   - ForeignHeaders 일치 → 해외
-//   - OldDomesticHeadersV1 일치 → 경고 로그 + 스킵
+//   - 구 포맷 헤더 → 자동 마이그레이션 후 재조회
 //   - 그 외 → 스킵(매매일지 시트 아님)
+//
+// 읽기 쿼터(분당 60회)를 아끼기 위해 **시트당 그리드 조회 1회**만 사용한다
+// (헤더는 조회 결과의 1행에서 얻는다).
+//
+// 조회 실패는 스킵하지 않고 **에러로 전파**한다. 일부 시트만 실패한 채 진행하면
+// 호출측(대시보드)이 부분 데이터로 시트를 통째로 재작성해 기존 내용을 잃는다.
 //
 // NFD/NFC 유니코드 중복 시트는 하나만 읽는다.
 func (w *Writer) ReadAllTrades(ctx context.Context) ([]model.Trade, error) {
@@ -38,17 +49,17 @@ func (w *Writer) ReadAllTrades(ctx context.Context) ([]model.Trade, error) {
 		}
 		seen[normalized] = true
 
-		headerVals, err := w.client.GetValues(ctx, sheetName+"!A1:Q1")
+		grid, err := w.client.GetRawGridData(ctx, sheetName, tradeGridRange)
 		if err != nil {
-			slog.Error("헤더 조회 실패", "sheet", sheetName, "err", err)
-			continue
+			return nil, fmt.Errorf("시트 '%s' 읽기 실패: %w", sheetName, err)
 		}
-		headerRow := extractHeaderRow(headerVals)
+		headerRow := headerFromGrid(grid)
 		if len(headerRow) == 0 {
 			continue
 		}
 
 		var isForeign bool
+		var newHeader []string
 		switch {
 		case headersEqual(headerRow, DomesticHeaders):
 			isForeign = false
@@ -56,24 +67,25 @@ func (w *Writer) ReadAllTrades(ctx context.Context) ([]model.Trade, error) {
 			isForeign = true
 		case headersEqual(headerRow, OldDomesticHeadersV2),
 			headersEqual(headerRow, OldDomesticHeadersV1):
-			// 구 포맷 → 신 포맷 자동 마이그레이션 후 읽기.
-			if err := w.migrateSheet(ctx, sheetName, headerRow, DomesticHeaders); err != nil {
-				slog.Error("자동 마이그레이션 실패, 스킵", "sheet", sheetName, "err", err)
-				continue
-			}
-			isForeign = false
+			isForeign, newHeader = false, DomesticHeaders
 		case headersEqual(headerRow, OldForeignHeadersV1):
-			if err := w.migrateSheet(ctx, sheetName, headerRow, ForeignHeaders); err != nil {
-				slog.Error("자동 마이그레이션 실패, 스킵", "sheet", sheetName, "err", err)
-				continue
-			}
-			isForeign = true
+			isForeign, newHeader = true, ForeignHeaders
 		default:
 			slog.Debug("시트 스킵(매매일지 헤더 불일치)", "sheet", sheetName)
 			continue
 		}
 
-		trades := w.readTradesFromSheet(ctx, sheetName, isForeign, normalized)
+		// 구 포맷이면 마이그레이션 후 재조회(열 삽입으로 앞서 읽은 그리드가 무효화된다).
+		if newHeader != nil {
+			if err := w.migrateSheet(ctx, sheetName, headerRow, newHeader); err != nil {
+				return nil, fmt.Errorf("시트 '%s' 자동 마이그레이션 실패: %w", sheetName, err)
+			}
+			if grid, err = w.client.GetRawGridData(ctx, sheetName, tradeGridRange); err != nil {
+				return nil, fmt.Errorf("시트 '%s' 마이그레이션 후 읽기 실패: %w", sheetName, err)
+			}
+		}
+
+		trades := tradesFromGrid(grid, isForeign, normalized)
 		allTrades = append(allTrades, trades...)
 		kind := "국내"
 		if isForeign {
@@ -86,16 +98,10 @@ func (w *Writer) ReadAllTrades(ctx context.Context) ([]model.Trade, error) {
 	return allTrades, nil
 }
 
-// readTradesFromSheet 는 개별 매매일지 시트에서 Trade 리스트를 반환한다.
+// tradesFromGrid 는 헤더 포함 그리드(1행=헤더)에서 데이터 행만 Trade 로 변환한다.
 // (Python _read_trades_from_sheet) account 는 정규화된 시트 이름.
-func (w *Writer) readTradesFromSheet(ctx context.Context, sheetName string, isForeign bool, account string) []model.Trade {
-	// 국내 12컬럼(A~L), 해외 17컬럼(A~Q) — 공통 범위 A2:Q10000 사용.
-	grid, err := w.client.GetRawGridData(ctx, sheetName, "A2:Q10000")
-	if err != nil {
-		slog.Error("시트 데이터 읽기 실패", "sheet", sheetName, "err", err)
-		return nil
-	}
-	if grid == nil {
+func tradesFromGrid(grid *gsheets.GridData, isForeign bool, account string) []model.Trade {
+	if grid == nil || len(grid.RowData) <= 1 {
 		return nil
 	}
 
@@ -104,8 +110,8 @@ func (w *Writer) readTradesFromSheet(ctx context.Context, sheetName string, isFo
 		minCols = 17
 	}
 
-	trades := make([]model.Trade, 0)
-	for _, row := range grid.RowData {
+	trades := make([]model.Trade, 0, len(grid.RowData)-1)
+	for _, row := range grid.RowData[1:] { // 1행(헤더) 제외
 		values := row.Values
 		if len(values) < minCols {
 			continue
@@ -120,6 +126,26 @@ func (w *Writer) readTradesFromSheet(ctx context.Context, sheetName string, isFo
 		trades = append(trades, tr)
 	}
 	return trades
+}
+
+// headerFromGrid 는 그리드 1행을 헤더 문자열 리스트로 추출한다.
+// A1:Q 범위로 읽으면 실제 컬럼 수보다 뒤쪽 빈 셀이 딸려올 수 있으므로 후행 공백은 제거한다
+// (headersEqual 은 길이까지 비교한다).
+func headerFromGrid(grid *gsheets.GridData) []string {
+	if grid == nil || len(grid.RowData) == 0 {
+		return nil
+	}
+	values := grid.RowData[0].Values
+	out := make([]string, len(values))
+	for i, cell := range values {
+		if s, ok := cellEffective(cell).(string); ok {
+			out[i] = s
+		}
+	}
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	return out
 }
 
 // gridRowToPlain 은 그리드 셀 리스트를 []interface{} 로 변환한다.

--- a/internal/writer/reader_api_test.go
+++ b/internal/writer/reader_api_test.go
@@ -1,0 +1,168 @@
+package writer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/kenshin579/auto-trading-journal/internal/sheets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gsheets "google.golang.org/api/sheets/v4"
+)
+
+// fakeSheets 는 Sheets API 를 흉내내며 어떤 경로가 몇 번 호출됐는지 기록한다.
+type fakeSheets struct {
+	mu sync.Mutex
+	// gridCalls: ranges 파라미터가 있는 Spreadsheets.Get (그리드 조회) 횟수
+	gridCalls int
+	// metaCalls: ranges 없는 Spreadsheets.Get (메타데이터/시트목록) 횟수
+	metaCalls int
+	// valuesCalls: Values.Get (values 엔드포인트) 횟수
+	valuesCalls int
+
+	sheetNames []string
+	gridBody   func(sheetName string) (int, string)
+}
+
+func (f *fakeSheets) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+
+	if idx := indexOfSubstr(r.URL.Path, "/values/"); idx >= 0 {
+		f.valuesCalls++
+		_, _ = w.Write([]byte(`{"values":[]}`))
+		return
+	}
+
+	ranges := r.URL.Query()["ranges"]
+	if len(ranges) == 0 {
+		f.metaCalls++
+		ss := &gsheets.Spreadsheet{}
+		for i, n := range f.sheetNames {
+			ss.Sheets = append(ss.Sheets, &gsheets.Sheet{
+				Properties: &gsheets.SheetProperties{Title: n, SheetId: int64(i)},
+			})
+		}
+		b, _ := json.Marshal(ss)
+		_, _ = w.Write(b)
+		return
+	}
+
+	f.gridCalls++
+	sheetName := ranges[0]
+	if i := indexOfSubstr(sheetName, "!"); i >= 0 {
+		sheetName = sheetName[:i]
+	}
+	status, body := f.gridBody(sheetName)
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
+}
+
+func indexOfSubstr(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// gridJSON 은 헤더 행 + 데이터 행들을 GridData 응답 JSON 으로 만든다.
+func gridJSON(header []string, rows [][]string) string {
+	toRow := func(cells []string) *gsheets.RowData {
+		rd := &gsheets.RowData{}
+		for _, c := range cells {
+			v := c
+			rd.Values = append(rd.Values, &gsheets.CellData{
+				FormattedValue: v,
+				EffectiveValue: &gsheets.ExtendedValue{StringValue: &v},
+			})
+		}
+		return rd
+	}
+	data := &gsheets.GridData{RowData: []*gsheets.RowData{toRow(header)}}
+	for _, r := range rows {
+		data.RowData = append(data.RowData, toRow(r))
+	}
+	ss := &gsheets.Spreadsheet{Sheets: []*gsheets.Sheet{{Data: []*gsheets.GridData{data}}}}
+	b, _ := json.Marshal(ss)
+	return string(b)
+}
+
+func newFakeWriter(t *testing.T, f *fakeSheets) *Writer {
+	t.Helper()
+	srv := httptest.NewServer(f)
+	t.Cleanup(srv.Close)
+	c, err := sheets.NewWithEndpoint(context.Background(), "test-sheet", srv.URL)
+	require.NoError(t, err)
+	return New(c)
+}
+
+func domesticRow() []string {
+	return []string{"2026-02-13", "매도", "005930", "삼성전자", "전기·전자", "반도체",
+		"10", "75000", "750000", "1500", "50000", "0.0714"}
+}
+
+// ReadAllTrades 는 시트당 그리드 1회만 읽어야 한다(헤더 전용 Values.Get 을 따로 호출하지 않는다).
+// 읽기 쿼터(분당 60)를 아끼기 위한 핵심 불변식.
+func TestReadAllTradesReadsOneRequestPerSheet(t *testing.T) {
+	f := &fakeSheets{
+		sheetNames: []string{"대시보드", "미래에셋증권_IRP", "미래에셋증권_ISA"},
+		gridBody: func(sheetName string) (int, string) {
+			if sheetName == "대시보드" {
+				return http.StatusOK, gridJSON([]string{"포트폴리오 요약"}, nil)
+			}
+			return http.StatusOK, gridJSON(DomesticHeaders, [][]string{domesticRow(), domesticRow()})
+		},
+	}
+	w := newFakeWriter(t, f)
+
+	trades, err := w.ReadAllTrades(context.Background())
+	require.NoError(t, err)
+
+	assert.Len(t, trades, 4, "매매일지 시트 2개 × 2행")
+	assert.Equal(t, 0, f.valuesCalls, "헤더 전용 Values.Get 은 더 이상 호출되지 않아야 한다")
+	assert.Equal(t, 3, f.gridCalls, "시트당 그리드 조회 1회")
+	assert.Equal(t, 1, f.metaCalls, "시트 목록 조회 1회")
+}
+
+// 시트 읽기가 실패하면 부분 데이터로 대시보드를 재작성하지 않도록 에러를 반환해야 한다.
+func TestReadAllTradesFailsFastOnReadError(t *testing.T) {
+	f := &fakeSheets{
+		sheetNames: []string{"미래에셋증권_IRP", "미래에셋증권_ISA"},
+		gridBody: func(sheetName string) (int, string) {
+			if sheetName == "미래에셋증권_ISA" {
+				return http.StatusBadRequest, `{"error":{"code":400,"message":"boom"}}`
+			}
+			return http.StatusOK, gridJSON(DomesticHeaders, [][]string{domesticRow()})
+		},
+	}
+	w := newFakeWriter(t, f)
+
+	trades, err := w.ReadAllTrades(context.Background())
+
+	require.Error(t, err, "한 시트라도 읽기에 실패하면 에러여야 한다")
+	assert.Contains(t, err.Error(), "미래에셋증권_ISA")
+	assert.Nil(t, trades)
+}
+
+// 헤더 뒤에 빈 셀이 패딩되어 오더라도 헤더 매칭에 성공해야 한다(A1:Q 범위로 읽기 때문).
+func TestReadAllTradesTrimsTrailingEmptyHeaderCells(t *testing.T) {
+	padded := append(append([]string{}, DomesticHeaders...), "", "", "", "", "")
+	f := &fakeSheets{
+		sheetNames: []string{"미래에셋증권_IRP"},
+		gridBody: func(string) (int, string) {
+			return http.StatusOK, gridJSON(padded, [][]string{domesticRow()})
+		},
+	}
+	w := newFakeWriter(t, f)
+
+	trades, err := w.ReadAllTrades(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, trades, 1)
+}


### PR DESCRIPTION
## 배경

`make run` 이 대시보드 갱신 단계에서 429 로 전체 시트 읽기에 실패하고, 대시보드를 갱신하지 못한 채 종료됐습니다.

```
level=ERROR msg="헤더 조회 실패" sheet=대시보드 err="... Error 429: Quota exceeded for quota metric
'Read requests' and limit 'Read requests per minute per user' ... quota_limit_value: 60"
...
level=INFO msg="전체 매매일지 읽기 완료" total=0
level=WARN msg="매매일지 시트에 데이터가 없어 대시보드를 갱신하지 않습니다"
```

### 원인

1. **읽기 경로에 재시도가 없었음** — `executeWithRetry`(429/5xx 지수 백오프)가 `batchUpdate` 에만 걸려 있어, 읽기(`Spreadsheets.Get` / `Values.Get`)와 값 쓰기(`values.update` 등)는 재시도 없이 즉시 실패했습니다.
2. **재시도 예산이 쿼터 창보다 짧았음** — `maxRetries=3`, 누적 대기 1+2+4 ≈ 7초. Sheets 쿼터는 분당 리셋이라 버킷이 비면 최대 60초를 기다려야 회복됩니다.
3. **읽기 호출 과다** — `ReadAllTrades` 가 시트당 2회(헤더 `Values.Get` + 그리드 `GetRawGridData`)를 써서 1회 실행에 읽기 약 32회를 소모했습니다. 쿼터가 60/분이라 1분 안에 두 번 실행하면 확정적으로 초과합니다.
4. **읽기 실패를 삼킴 (잠재적 데이터 손실)** — `reader.go` 가 실패를 `continue` 로 넘겨, 일부 시트만 429 가 나면 **부분 데이터로 대시보드를 통째로 재작성**할 수 있었습니다. 이번엔 전 시트가 실패해 `total=0` 으로 갱신이 스킵되면서 우연히 드러나지 않았습니다.

## 변경 사항

- 모든 Sheets 호출(읽기 + 값 쓰기)을 `executeWithRetry` 로 감쌈
- `maxRetries` 3 → 6 (누적 대기 약 63초 > 쿼터 창 60초). 백오프를 `retryWait` / `retrySleep` 로 분리해 테스트 가능하게 함
- `ReadAllTrades`: 시트당 그리드 **1회**(`A1:Q10000`)만 읽고 헤더는 1행에서 추출 → 실행당 읽기 **32회 → 19회**. 후행 빈 헤더 셀은 트림
- `ReadAllTrades`: 읽기/자동 마이그레이션 실패를 에러로 전파(fail-fast)
- `sheets.NewWithEndpoint` 추가 — httptest fake 서버로 API 계층을 실제 테스트
- CLAUDE.md 에 쿼터/재시도 예산 및 fail-fast 불변식 문서화

## 테스트 계획

- [x] `go test ./...` 전체 통과
- [x] 신규 테스트(수정 전 실패 확인 후 작성)
  - `TestRetryWaitBudgetCoversQuotaWindow` — 재시도 누적 대기 >= 60초 불변식
  - `TestGetValuesRetriesOnRateLimit` / `TestGridAndMetadataRetryOnRateLimit` / `TestValueWritesRetryOnRateLimit` — fake 엔드포인트로 429 재시도 검증
  - `TestReadAllTradesReadsOneRequestPerSheet` — 시트당 그리드 1회, `Values.Get` 0회
  - `TestReadAllTradesFailsFastOnReadError` — 한 시트라도 실패하면 에러 반환
  - `TestReadAllTradesTrimsTrailingEmptyHeaderCells` — 후행 빈 헤더 셀 패딩 대응
- [x] 실제 `make run` 을 1분 내 2회 연속 실행 — 429 없이 대시보드 갱신 완료(7,800건)

## 남은 여지 (이번 PR 범위 외)

`processFile` 도 파일당 읽기 4~5회(`ensureNewFormat` 헤더 + `GetExistingKeys` 그리드 + `FindLastRow` 메타데이터/그리드)를 쓰며 같은 방식으로 1~2회로 합칠 수 있습니다. 다만 현재 19회면 쿼터 대비 3배 여유가 있고 재시도가 백스톱이라 리스크 대비 이득이 적어 제외했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)